### PR TITLE
Phase 1b — Ribbon + LeftPane + SectionSwitcher + RightPane (with stubs)

### DIFF
--- a/ui/tandem/src/app/AppShell.tsx
+++ b/ui/tandem/src/app/AppShell.tsx
@@ -1,24 +1,35 @@
 import { useState, type CSSProperties } from "react";
 
 import { useConnectionStatus } from "@/features/connection/hooks/useConnectionStatus";
+import { LeftPane } from "@/features/left-pane/ui/LeftPane";
+import { Ribbon, type AppId } from "@/features/ribbon/ui/Ribbon";
+import { RightPane } from "@/features/right-pane/ui/RightPane";
+import type { SectionId } from "@/features/sections/ui/SectionSwitcher";
+import { StubBody } from "@/features/sections/ui/StubBody";
 import { StatusBar } from "@/features/status/ui/StatusBar";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import { ToastViewport } from "@/features/toasts/ToastViewport";
 
 const RIBBON_WIDTH = 44;
-const LEFT_PANE_WIDTH = 280;
+const LEFT_PANE_EXPANDED = 280;
+const LEFT_PANE_COLLAPSED = 52;
 const RIGHT_PANE_EXPANDED = 320;
 const RIGHT_PANE_COLLAPSED = 44;
 
-type SectionId = "chat" | "projects" | "memory" | "workflows" | "skills";
-
-const zoneBase: CSSProperties = {
+const mainPaneStyle: CSSProperties = {
   height: "100%",
+  background: "var(--color-canvas)",
+  display: "flex",
+  flexDirection: "column",
+  minHeight: 0,
   overflow: "hidden",
 };
 
 export const AppShell = () => {
-  const [section] = useState<SectionId>("chat");
-  const [rightCollapsed] = useState(true);
+  const [activeApp, setActiveApp] = useState<AppId>("chat");
+  const [section, setSection] = useState<SectionId>("chat");
+  const [leftCollapsed, setLeftCollapsed] = useState(false);
+  const [rightCollapsed, setRightCollapsed] = useState(true);
 
   const connectionStatus = useConnectionStatus();
   const sessions = useChatSessionStore((s) => s.sessions);
@@ -27,13 +38,16 @@ export const AppShell = () => {
     ? sessions.find((s) => s.id === activeSessionId)
     : undefined;
 
+  const leftWidth = leftCollapsed ? LEFT_PANE_COLLAPSED : LEFT_PANE_EXPANDED;
   const rightWidth = rightCollapsed ? RIGHT_PANE_COLLAPSED : RIGHT_PANE_EXPANDED;
+
+  const isStubSection = section !== "chat";
 
   return (
     <div
       style={{
         display: "grid",
-        gridTemplateColumns: `${RIBBON_WIDTH}px ${LEFT_PANE_WIDTH}px 1fr ${rightWidth}px`,
+        gridTemplateColumns: `${RIBBON_WIDTH}px ${leftWidth}px 1fr ${rightWidth}px`,
         gridTemplateRows: "1fr var(--statusbar-height)",
         gridTemplateAreas: `
           "ribbon left main right"
@@ -46,46 +60,31 @@ export const AppShell = () => {
         fontFamily: "var(--font-ui)",
       }}
     >
-      <div
-        data-testid="zone-ribbon"
-        style={{
-          ...zoneBase,
-          gridArea: "ribbon",
-          width: `${RIBBON_WIDTH}px`,
-          background: "var(--color-bg)",
-          borderRight: "1px solid var(--color-border-subtle)",
-        }}
-      />
-      <div
-        data-testid="zone-left-pane"
-        style={{
-          ...zoneBase,
-          gridArea: "left",
-          width: `${LEFT_PANE_WIDTH}px`,
-          background: "var(--color-surface)",
-          borderRight: "1px solid var(--color-border-subtle)",
-        }}
-      />
+      <div style={{ gridArea: "ribbon", overflow: "hidden" }}>
+        <Ribbon activeApp={activeApp} onActivate={setActiveApp} />
+      </div>
+      <div style={{ gridArea: "left", overflow: "hidden" }}>
+        <LeftPane
+          collapsed={leftCollapsed}
+          onToggleCollapsed={() => setLeftCollapsed((c) => !c)}
+          activeSection={section}
+          onSectionChange={setSection}
+          onNewChat={() => {}}
+        />
+      </div>
       <div
         data-testid="zone-main"
         data-section={section}
-        style={{
-          ...zoneBase,
-          gridArea: "main",
-          background: "var(--color-canvas)",
-        }}
-      />
-      <div
-        data-testid="zone-right-pane"
-        data-collapsed={String(rightCollapsed)}
-        style={{
-          ...zoneBase,
-          gridArea: "right",
-          width: `${rightWidth}px`,
-          background: "var(--color-surface)",
-          borderLeft: "1px solid var(--color-border-subtle)",
-        }}
-      />
+        style={mainPaneStyle}
+      >
+        {isStubSection && <StubBody section={section} />}
+      </div>
+      <div style={{ gridArea: "right", overflow: "hidden" }}>
+        <RightPane
+          collapsed={rightCollapsed}
+          onToggleCollapsed={() => setRightCollapsed((c) => !c)}
+        />
+      </div>
       <div style={{ gridArea: "status" }}>
         <StatusBar
           connectionStatus={connectionStatus}
@@ -96,6 +95,7 @@ export const AppShell = () => {
           skillsCount={0}
         />
       </div>
+      <ToastViewport />
     </div>
   );
 };

--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 vi.mock("@/shared/api/acpConnection", () => ({
   getClient: vi.fn(() => new Promise(() => {})),
@@ -7,10 +8,12 @@ vi.mock("@/shared/api/acpConnection", () => ({
 
 import { AppShell } from "@/app/AppShell";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import { useToastStore } from "@/features/toasts/toastStore";
 
 describe("AppShell", () => {
   beforeEach(() => {
     useChatSessionStore.setState({ sessions: [], activeSessionId: null });
+    useToastStore.setState({ toasts: [] });
   });
 
   it("renders all 5 zones", () => {
@@ -27,6 +30,13 @@ describe("AppShell", () => {
     const rightPane = screen.getByTestId("zone-right-pane");
     expect(rightPane).toHaveAttribute("data-collapsed", "true");
     expect(rightPane).toHaveStyle({ width: "44px" });
+  });
+
+  it("starts with the left pane expanded at 280px", () => {
+    render(<AppShell />);
+    const leftPane = screen.getByTestId("zone-left-pane");
+    expect(leftPane).toHaveAttribute("data-collapsed", "false");
+    expect(leftPane).toHaveStyle({ width: "280px" });
   });
 
   it("uses the design's fixed widths for ribbon, left pane, status bar", () => {
@@ -97,6 +107,65 @@ describe("AppShell", () => {
     expect(screen.getByTestId("zone-main")).toHaveAttribute(
       "data-section",
       "chat",
+    );
+  });
+
+  it("clicking a section button changes the active section", async () => {
+    const user = userEvent.setup();
+    render(<AppShell />);
+    await user.click(screen.getByTestId("section-btn-projects"));
+    expect(screen.getByTestId("zone-main")).toHaveAttribute(
+      "data-section",
+      "projects",
+    );
+  });
+
+  it("non-Chat section renders StubBody in the main pane with the correct copy", async () => {
+    const user = userEvent.setup();
+    render(<AppShell />);
+    await user.click(screen.getByTestId("section-btn-workflows"));
+    const stub = screen.getByTestId("stub-body");
+    expect(stub).toHaveAttribute("data-section", "workflows");
+    expect(stub).toHaveTextContent("Workflows is shipping in v1.3.");
+  });
+
+  it("Chat section does not render a StubBody in the main pane", () => {
+    render(<AppShell />);
+    expect(screen.queryByTestId("stub-body")).not.toBeInTheDocument();
+  });
+
+  it("clicking a non-live ribbon slot shows a toast in the viewport", async () => {
+    const user = userEvent.setup();
+    render(<AppShell />);
+    await user.click(screen.getByTestId("ribbon-app-email"));
+    expect(screen.getByTestId("toast")).toHaveTextContent(
+      "Email — coming soon",
+    );
+  });
+
+  it("clicking the left pane toggle collapses the pane to 52px", async () => {
+    const user = userEvent.setup();
+    render(<AppShell />);
+    await user.click(screen.getByTestId("left-pane-toggle"));
+    const leftPane = screen.getByTestId("zone-left-pane");
+    expect(leftPane).toHaveAttribute("data-collapsed", "true");
+    expect(leftPane).toHaveStyle({ width: "52px" });
+  });
+
+  it("clicking the right pane toggle expands the pane to 320px", async () => {
+    const user = userEvent.setup();
+    render(<AppShell />);
+    await user.click(screen.getByTestId("right-pane-toggle"));
+    const rightPane = screen.getByTestId("zone-right-pane");
+    expect(rightPane).toHaveAttribute("data-collapsed", "false");
+    expect(rightPane).toHaveStyle({ width: "320px" });
+  });
+
+  it("ribbon marks Chat as active", () => {
+    render(<AppShell />);
+    expect(screen.getByTestId("ribbon-app-chat")).toHaveAttribute(
+      "data-active",
+      "true",
     );
   });
 });

--- a/ui/tandem/src/features/left-pane/ui/LeftPane.tsx
+++ b/ui/tandem/src/features/left-pane/ui/LeftPane.tsx
@@ -1,0 +1,203 @@
+import { PanelLeft, Plus, Search } from "lucide-react";
+import { useMemo, useState, type CSSProperties } from "react";
+
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import {
+  SectionSwitcher,
+  type SectionId,
+} from "@/features/sections/ui/SectionSwitcher";
+
+interface LeftPaneProps {
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+  activeSection: SectionId;
+  onSectionChange: (id: SectionId) => void;
+  onNewChat: () => void;
+}
+
+const EXPANDED_WIDTH = 280;
+const COLLAPSED_WIDTH = 52;
+
+const paneStyle = (collapsed: boolean): CSSProperties => ({
+  width: collapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH,
+  flex: `0 0 ${collapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH}px`,
+  height: "100%",
+  background: "var(--color-surface)",
+  borderRight: "1px solid var(--color-border-subtle)",
+  display: "flex",
+  flexDirection: "column",
+  minHeight: 0,
+});
+
+const headerStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "var(--space-1)",
+  padding: "var(--space-2)",
+  borderBottom: "1px solid var(--color-border-subtle)",
+  height: 40,
+  flex: "0 0 40px",
+};
+
+const iconButtonStyle: CSSProperties = {
+  width: 28,
+  height: 28,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  background: "transparent",
+  border: 0,
+  borderRadius: "var(--radius-sm)",
+  color: "var(--color-text-muted)",
+  cursor: "pointer",
+  flex: "0 0 auto",
+};
+
+const searchWrapStyle: CSSProperties = {
+  position: "relative",
+  flex: 1,
+  display: "flex",
+  alignItems: "center",
+  minWidth: 0,
+};
+
+const searchInputStyle: CSSProperties = {
+  width: "100%",
+  height: 28,
+  padding: "0 8px 0 28px",
+  background: "var(--color-surface-sunken)",
+  border: "1px solid transparent",
+  borderRadius: "var(--radius-sm)",
+  color: "var(--color-text)",
+  fontSize: "var(--text-sm)",
+  outline: "none",
+};
+
+const searchIconWrapStyle: CSSProperties = {
+  position: "absolute",
+  left: 8,
+  top: "50%",
+  transform: "translateY(-50%)",
+  color: "var(--color-text-muted)",
+  pointerEvents: "none",
+  display: "flex",
+};
+
+const bodyStyle: CSSProperties = {
+  flex: 1,
+  minHeight: 0,
+  overflowY: "auto",
+};
+
+const sessionRowStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  padding: "6px 12px",
+  fontSize: "var(--text-sm)",
+  color: "var(--color-text-secondary)",
+  cursor: "pointer",
+  whiteSpace: "nowrap",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+};
+
+const emptyHintStyle: CSSProperties = {
+  padding: "var(--space-4)",
+  fontSize: "var(--text-sm)",
+  color: "var(--color-text-muted)",
+  textAlign: "center",
+};
+
+export const LeftPane = ({
+  collapsed,
+  onToggleCollapsed,
+  activeSection,
+  onSectionChange,
+  onNewChat,
+}: LeftPaneProps) => {
+  const [search, setSearch] = useState("");
+  const sessions = useChatSessionStore((s) => s.sessions);
+
+  const filteredSessions = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return sessions;
+    return sessions.filter((session) =>
+      session.title.toLowerCase().includes(q),
+    );
+  }, [sessions, search]);
+
+  return (
+    <div
+      data-testid="zone-left-pane"
+      data-collapsed={String(collapsed)}
+      style={paneStyle(collapsed)}
+    >
+      <div style={headerStyle}>
+        <button
+          type="button"
+          data-testid="left-pane-toggle"
+          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          onClick={onToggleCollapsed}
+          style={iconButtonStyle}
+        >
+          <PanelLeft size={15} aria-hidden="true" />
+        </button>
+        {!collapsed && (
+          <>
+            <div style={searchWrapStyle}>
+              <span style={searchIconWrapStyle}>
+                <Search size={13} aria-hidden="true" />
+              </span>
+              <input
+                type="text"
+                data-testid="left-pane-search"
+                placeholder="Search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                style={searchInputStyle}
+              />
+            </div>
+            <button
+              type="button"
+              data-testid="left-pane-new-chat"
+              aria-label="New chat"
+              onClick={onNewChat}
+              style={iconButtonStyle}
+            >
+              <Plus size={15} aria-hidden="true" />
+            </button>
+          </>
+        )}
+      </div>
+      {!collapsed && (
+        <>
+          <SectionSwitcher
+            activeSection={activeSection}
+            onSectionChange={onSectionChange}
+          />
+          <div style={bodyStyle}>
+            {activeSection === "chat" ? (
+              filteredSessions.length === 0 ? (
+                <div style={emptyHintStyle}>
+                  {sessions.length === 0
+                    ? "No chats yet."
+                    : "No matching chats."}
+                </div>
+              ) : (
+                filteredSessions.map((session) => (
+                  <div
+                    key={session.id}
+                    data-testid={`session-row-${session.id}`}
+                    style={sessionRowStyle}
+                  >
+                    {session.title}
+                  </div>
+                ))
+              )
+            ) : null}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/ui/tandem/src/features/left-pane/ui/__tests__/LeftPane.test.tsx
+++ b/ui/tandem/src/features/left-pane/ui/__tests__/LeftPane.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { LeftPane } from "@/features/left-pane/ui/LeftPane";
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+
+const seedSessions = (
+  titles: string[] = ["Onboarding doc", "Bug triage", "Refactor plan"],
+) => {
+  useChatSessionStore.setState({
+    sessions: titles.map((title, i) => ({
+      id: `s${i}`,
+      title,
+      createdAt: "",
+      updatedAt: "",
+      messageCount: 0,
+    })),
+    activeSessionId: null,
+  });
+};
+
+const noopProps = {
+  collapsed: false,
+  onToggleCollapsed: () => {},
+  activeSection: "chat" as const,
+  onSectionChange: () => {},
+  onNewChat: () => {},
+};
+
+describe("LeftPane", () => {
+  beforeEach(() => {
+    useChatSessionStore.setState({ sessions: [], activeSessionId: null });
+  });
+
+  it("renders at 280px when expanded", () => {
+    render(<LeftPane {...noopProps} collapsed={false} />);
+    const pane = screen.getByTestId("zone-left-pane");
+    expect(pane).toHaveAttribute("data-collapsed", "false");
+    expect(pane).toHaveStyle({ width: "280px" });
+  });
+
+  it("renders at 52px when collapsed", () => {
+    render(<LeftPane {...noopProps} collapsed={true} />);
+    const pane = screen.getByTestId("zone-left-pane");
+    expect(pane).toHaveAttribute("data-collapsed", "true");
+    expect(pane).toHaveStyle({ width: "52px" });
+  });
+
+  it("clicking the toggle button calls onToggleCollapsed", async () => {
+    const user = userEvent.setup();
+    const onToggleCollapsed = vi.fn();
+    render(
+      <LeftPane
+        {...noopProps}
+        collapsed={false}
+        onToggleCollapsed={onToggleCollapsed}
+      />,
+    );
+    await user.click(screen.getByTestId("left-pane-toggle"));
+    expect(onToggleCollapsed).toHaveBeenCalledOnce();
+  });
+
+  it("shows search input and + button when expanded", () => {
+    render(<LeftPane {...noopProps} collapsed={false} />);
+    expect(screen.getByTestId("left-pane-search")).toBeInTheDocument();
+    expect(screen.getByTestId("left-pane-new-chat")).toBeInTheDocument();
+  });
+
+  it("hides search input and + button when collapsed", () => {
+    render(<LeftPane {...noopProps} collapsed={true} />);
+    expect(screen.queryByTestId("left-pane-search")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("left-pane-new-chat")).not.toBeInTheDocument();
+  });
+
+  it("clicking the + button calls onNewChat", async () => {
+    const user = userEvent.setup();
+    const onNewChat = vi.fn();
+    render(<LeftPane {...noopProps} onNewChat={onNewChat} />);
+    await user.click(screen.getByTestId("left-pane-new-chat"));
+    expect(onNewChat).toHaveBeenCalledOnce();
+  });
+
+  it("hosts the SectionSwitcher with the active section marked", () => {
+    render(<LeftPane {...noopProps} activeSection="memory" />);
+    expect(screen.getByTestId("section-switcher")).toBeInTheDocument();
+    expect(screen.getByTestId("section-btn-memory")).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+  });
+
+  it("clicking a section button propagates onSectionChange", async () => {
+    const user = userEvent.setup();
+    const onSectionChange = vi.fn();
+    render(
+      <LeftPane
+        {...noopProps}
+        activeSection="chat"
+        onSectionChange={onSectionChange}
+      />,
+    );
+    await user.click(screen.getByTestId("section-btn-projects"));
+    expect(onSectionChange).toHaveBeenCalledWith("projects");
+  });
+
+  it("Chat section: renders the session list from chatSessionStore", () => {
+    seedSessions(["Apple plans", "Banana split", "Carrot recipe"]);
+    render(<LeftPane {...noopProps} activeSection="chat" />);
+    const rows = screen
+      .getAllByTestId(/session-row-/)
+      .map((el) => el.textContent);
+    expect(rows).toEqual(
+      expect.arrayContaining(["Apple plans", "Banana split", "Carrot recipe"]),
+    );
+  });
+
+  it("Chat section: typing in search filters the session list by title (case-insensitive)", async () => {
+    const user = userEvent.setup();
+    seedSessions(["Apple plans", "Banana split", "Carrot recipe"]);
+    render(<LeftPane {...noopProps} activeSection="chat" />);
+    await user.type(screen.getByTestId("left-pane-search"), "ban");
+    const rows = screen.getAllByTestId(/session-row-/);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent("Banana split");
+  });
+
+  it("Chat section: clearing the search shows all sessions again", async () => {
+    const user = userEvent.setup();
+    seedSessions(["Apple", "Banana"]);
+    render(<LeftPane {...noopProps} activeSection="chat" />);
+    const searchInput = screen.getByTestId("left-pane-search");
+    await user.type(searchInput, "ban");
+    expect(screen.getAllByTestId(/session-row-/)).toHaveLength(1);
+    await user.clear(searchInput);
+    expect(screen.getAllByTestId(/session-row-/)).toHaveLength(2);
+  });
+
+  it("non-Chat section: does not render the session list", () => {
+    seedSessions(["A", "B"]);
+    render(<LeftPane {...noopProps} activeSection="projects" />);
+    expect(screen.queryByTestId(/session-row-/)).not.toBeInTheDocument();
+  });
+
+  it("collapsed: does not render the section switcher or session list", () => {
+    seedSessions(["A"]);
+    render(<LeftPane {...noopProps} collapsed={true} activeSection="chat" />);
+    expect(screen.queryByTestId("section-switcher")).not.toBeInTheDocument();
+    expect(screen.queryByTestId(/session-row-/)).not.toBeInTheDocument();
+  });
+
+  it("Chat section: live updates from chatSessionStore add new rows", () => {
+    seedSessions(["Original"]);
+    render(<LeftPane {...noopProps} activeSection="chat" />);
+    expect(screen.getAllByTestId(/session-row-/)).toHaveLength(1);
+    act(() => {
+      useChatSessionStore.setState({
+        sessions: [
+          ...useChatSessionStore.getState().sessions,
+          {
+            id: "new",
+            title: "Added later",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 0,
+          },
+        ],
+      });
+    });
+    expect(screen.getAllByTestId(/session-row-/)).toHaveLength(2);
+  });
+});

--- a/ui/tandem/src/features/ribbon/ui/Ribbon.tsx
+++ b/ui/tandem/src/features/ribbon/ui/Ribbon.tsx
@@ -1,0 +1,140 @@
+import {
+  Calendar,
+  Code2,
+  FolderKanban,
+  Mail,
+  MessageSquare,
+  Plug,
+  Settings,
+  type LucideIcon,
+} from "lucide-react";
+import type { CSSProperties } from "react";
+
+import { useToastStore } from "@/features/toasts/toastStore";
+
+export type AppId = "chat" | "email" | "calendar" | "projects" | "editor";
+
+interface AppSlot {
+  id: AppId;
+  label: string;
+  icon: LucideIcon;
+  live: boolean;
+}
+
+const APP_SLOTS: AppSlot[] = [
+  { id: "chat", label: "Chat", icon: MessageSquare, live: true },
+  { id: "email", label: "Email", icon: Mail, live: false },
+  { id: "calendar", label: "Calendar", icon: Calendar, live: false },
+  { id: "projects", label: "Projects", icon: FolderKanban, live: false },
+  { id: "editor", label: "Editor", icon: Code2, live: false },
+];
+
+interface RibbonProps {
+  activeApp: AppId;
+  onActivate: (id: AppId) => void;
+}
+
+const railStyle: CSSProperties = {
+  width: 44,
+  flex: "0 0 44px",
+  height: "100%",
+  background: "var(--color-bg)",
+  borderRight: "1px solid var(--color-border-subtle)",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  padding: "var(--space-2) 0",
+  userSelect: "none",
+};
+
+const groupStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: 2,
+};
+
+const slotButtonStyle = (active: boolean): CSSProperties => ({
+  position: "relative",
+  width: 32,
+  height: 32,
+  borderRadius: "var(--radius-sm)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  background: active ? "var(--color-accent-dim)" : "transparent",
+  border: 0,
+  color: active ? "var(--color-accent)" : "var(--color-text-muted)",
+  cursor: "pointer",
+});
+
+const indicatorStyle: CSSProperties = {
+  position: "absolute",
+  left: -7,
+  top: 6,
+  bottom: 6,
+  width: 2,
+  background: "var(--color-accent)",
+  borderRadius: "0 2px 2px 0",
+};
+
+export const Ribbon = ({ activeApp, onActivate }: RibbonProps) => {
+  const addToast = useToastStore((s) => s.addToast);
+
+  const handleSlotClick = (slot: AppSlot) => {
+    if (slot.live) {
+      onActivate(slot.id);
+    } else {
+      addToast(`${slot.label} — coming soon`);
+    }
+  };
+
+  return (
+    <div data-testid="zone-ribbon" style={railStyle}>
+      <div data-testid="ribbon-apps" style={groupStyle}>
+        {APP_SLOTS.map((slot) => {
+          const active = slot.id === activeApp;
+          const Icon = slot.icon;
+          return (
+            <button
+              key={slot.id}
+              type="button"
+              data-testid={`ribbon-app-${slot.id}`}
+              data-app-id={slot.id}
+              data-active={String(active)}
+              title={slot.live ? slot.label : `${slot.label} (coming soon)`}
+              onClick={() => handleSlotClick(slot)}
+              style={slotButtonStyle(active)}
+            >
+              {active && <span style={indicatorStyle} aria-hidden="true" />}
+              <Icon size={16} aria-hidden="true" />
+            </button>
+          );
+        })}
+      </div>
+      <div style={{ flex: 1 }} />
+      <div data-testid="ribbon-footer" style={groupStyle}>
+        <button
+          type="button"
+          data-testid="ribbon-plugins"
+          aria-label="Plugin marketplace"
+          title="Plugin marketplace (coming soon)"
+          onClick={() => addToast("Plugin marketplace — coming soon")}
+          style={slotButtonStyle(false)}
+        >
+          <Plug size={16} aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          data-testid="ribbon-settings"
+          aria-label="Settings"
+          title="Settings (coming soon)"
+          onClick={() => addToast("Settings — coming soon")}
+          style={slotButtonStyle(false)}
+        >
+          <Settings size={16} aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/ui/tandem/src/features/ribbon/ui/__tests__/Ribbon.test.tsx
+++ b/ui/tandem/src/features/ribbon/ui/__tests__/Ribbon.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { Ribbon } from "@/features/ribbon/ui/Ribbon";
+import { useToastStore } from "@/features/toasts/toastStore";
+
+describe("Ribbon", () => {
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [] });
+  });
+
+  it("renders 5 app slots in order: chat, email, calendar, projects, editor", () => {
+    render(<Ribbon activeApp="chat" onActivate={() => {}} />);
+    const apps = within(screen.getByTestId("ribbon-apps")).getAllByRole(
+      "button",
+    );
+    const ids = apps.map((b) => b.getAttribute("data-app-id"));
+    expect(ids).toEqual(["chat", "email", "calendar", "projects", "editor"]);
+  });
+
+  it("renders Plugins and Settings buttons in the footer", () => {
+    render(<Ribbon activeApp="chat" onActivate={() => {}} />);
+    const footer = within(screen.getByTestId("ribbon-footer"));
+    expect(footer.getByRole("button", { name: /plugin/i })).toBeInTheDocument();
+    expect(footer.getByRole("button", { name: /settings/i })).toBeInTheDocument();
+  });
+
+  it("marks the active app with data-active=true and the others false", () => {
+    render(<Ribbon activeApp="chat" onActivate={() => {}} />);
+    expect(screen.getByTestId("ribbon-app-chat")).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+    expect(screen.getByTestId("ribbon-app-email")).toHaveAttribute(
+      "data-active",
+      "false",
+    );
+  });
+
+  it("clicking the live Chat slot calls onActivate('chat')", async () => {
+    const user = userEvent.setup();
+    const onActivate = vi.fn();
+    render(<Ribbon activeApp="email" onActivate={onActivate} />);
+    await user.click(screen.getByTestId("ribbon-app-chat"));
+    expect(onActivate).toHaveBeenCalledWith("chat");
+  });
+
+  it("clicking a non-live slot fires '<Label> — coming soon' toast and does NOT call onActivate", async () => {
+    const user = userEvent.setup();
+    const onActivate = vi.fn();
+    render(<Ribbon activeApp="chat" onActivate={onActivate} />);
+    await user.click(screen.getByTestId("ribbon-app-email"));
+    expect(onActivate).not.toHaveBeenCalled();
+    expect(useToastStore.getState().toasts.map((t) => t.message)).toEqual([
+      "Email — coming soon",
+    ]);
+  });
+
+  it("clicking Plugins fires a coming-soon toast", async () => {
+    const user = userEvent.setup();
+    render(<Ribbon activeApp="chat" onActivate={() => {}} />);
+    await user.click(screen.getByTestId("ribbon-plugins"));
+    expect(useToastStore.getState().toasts[0]?.message).toMatch(/coming soon/i);
+    expect(useToastStore.getState().toasts[0]?.message).toMatch(/plugin/i);
+  });
+
+  it("clicking Settings fires a coming-soon toast", async () => {
+    const user = userEvent.setup();
+    render(<Ribbon activeApp="chat" onActivate={() => {}} />);
+    await user.click(screen.getByTestId("ribbon-settings"));
+    expect(useToastStore.getState().toasts[0]?.message).toMatch(/coming soon/i);
+    expect(useToastStore.getState().toasts[0]?.message).toMatch(/settings/i);
+  });
+
+  it("each slot has a tooltip with the label, suffixed with '(coming soon)' for non-live", () => {
+    render(<Ribbon activeApp="chat" onActivate={() => {}} />);
+    expect(screen.getByTestId("ribbon-app-chat")).toHaveAttribute(
+      "title",
+      "Chat",
+    );
+    expect(screen.getByTestId("ribbon-app-email")).toHaveAttribute(
+      "title",
+      "Email (coming soon)",
+    );
+  });
+});

--- a/ui/tandem/src/features/right-pane/ui/RightPane.tsx
+++ b/ui/tandem/src/features/right-pane/ui/RightPane.tsx
@@ -1,0 +1,77 @@
+import { PanelRight } from "lucide-react";
+import type { CSSProperties } from "react";
+
+interface RightPaneProps {
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+}
+
+const EXPANDED_WIDTH = 320;
+const COLLAPSED_WIDTH = 44;
+
+const paneStyle = (collapsed: boolean): CSSProperties => ({
+  width: collapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH,
+  flex: `0 0 ${collapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH}px`,
+  height: "100%",
+  background: "var(--color-surface)",
+  borderLeft: "1px solid var(--color-border-subtle)",
+  display: "flex",
+  flexDirection: "column",
+  minHeight: 0,
+});
+
+const headerStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: "var(--space-1)",
+  padding: "var(--space-2)",
+  borderBottom: "1px solid var(--color-border-subtle)",
+  height: 40,
+  flex: "0 0 40px",
+};
+
+const iconButtonStyle: CSSProperties = {
+  width: 28,
+  height: 28,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  background: "transparent",
+  border: 0,
+  borderRadius: "var(--radius-sm)",
+  color: "var(--color-text-muted)",
+  cursor: "pointer",
+};
+
+const placeholderStyle: CSSProperties = {
+  flex: 1,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "var(--space-6)",
+  textAlign: "center",
+  color: "var(--color-text-muted)",
+  fontSize: "var(--text-sm)",
+};
+
+export const RightPane = ({ collapsed, onToggleCollapsed }: RightPaneProps) => (
+  <div
+    data-testid="zone-right-pane"
+    data-collapsed={String(collapsed)}
+    style={paneStyle(collapsed)}
+  >
+    <div style={headerStyle}>
+      <button
+        type="button"
+        data-testid="right-pane-toggle"
+        aria-label={collapsed ? "Expand notes panel" : "Collapse notes panel"}
+        onClick={onToggleCollapsed}
+        style={iconButtonStyle}
+      >
+        <PanelRight size={15} aria-hidden="true" />
+      </button>
+    </div>
+    {!collapsed && <div style={placeholderStyle}>Notes coming in v1.4</div>}
+  </div>
+);

--- a/ui/tandem/src/features/right-pane/ui/__tests__/RightPane.test.tsx
+++ b/ui/tandem/src/features/right-pane/ui/__tests__/RightPane.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { RightPane } from "@/features/right-pane/ui/RightPane";
+
+describe("RightPane", () => {
+  it("renders at 44px when collapsed", () => {
+    render(<RightPane collapsed={true} onToggleCollapsed={() => {}} />);
+    const pane = screen.getByTestId("zone-right-pane");
+    expect(pane).toHaveAttribute("data-collapsed", "true");
+    expect(pane).toHaveStyle({ width: "44px" });
+  });
+
+  it("renders at 320px when expanded", () => {
+    render(<RightPane collapsed={false} onToggleCollapsed={() => {}} />);
+    const pane = screen.getByTestId("zone-right-pane");
+    expect(pane).toHaveAttribute("data-collapsed", "false");
+    expect(pane).toHaveStyle({ width: "320px" });
+  });
+
+  it("clicking the toggle button calls onToggleCollapsed", async () => {
+    const user = userEvent.setup();
+    const onToggleCollapsed = vi.fn();
+    render(
+      <RightPane
+        collapsed={true}
+        onToggleCollapsed={onToggleCollapsed}
+      />,
+    );
+    await user.click(screen.getByTestId("right-pane-toggle"));
+    expect(onToggleCollapsed).toHaveBeenCalledOnce();
+  });
+
+  it("expanded view shows 'Notes coming in v1.4' placeholder", () => {
+    render(<RightPane collapsed={false} onToggleCollapsed={() => {}} />);
+    expect(screen.getByTestId("zone-right-pane")).toHaveTextContent(
+      "Notes coming in v1.4",
+    );
+  });
+
+  it("collapsed view does not show the placeholder text", () => {
+    render(<RightPane collapsed={true} onToggleCollapsed={() => {}} />);
+    expect(screen.getByTestId("zone-right-pane")).not.toHaveTextContent(
+      "Notes coming in v1.4",
+    );
+  });
+});

--- a/ui/tandem/src/features/sections/ui/SectionSwitcher.tsx
+++ b/ui/tandem/src/features/sections/ui/SectionSwitcher.tsx
@@ -1,0 +1,86 @@
+import {
+  Brain,
+  FolderKanban,
+  MessageSquare,
+  Sparkles,
+  Workflow,
+  type LucideIcon,
+} from "lucide-react";
+import type { CSSProperties } from "react";
+
+export type SectionId =
+  | "chat"
+  | "projects"
+  | "memory"
+  | "workflows"
+  | "skills";
+
+interface SectionDef {
+  id: SectionId;
+  label: string;
+  icon: LucideIcon;
+}
+
+export const SECTIONS: SectionDef[] = [
+  { id: "chat", label: "Chat", icon: MessageSquare },
+  { id: "projects", label: "Projects", icon: FolderKanban },
+  { id: "memory", label: "Memory", icon: Brain },
+  { id: "workflows", label: "Workflows", icon: Workflow },
+  { id: "skills", label: "Skills", icon: Sparkles },
+];
+
+interface SectionSwitcherProps {
+  activeSection: SectionId;
+  onSectionChange: (id: SectionId) => void;
+}
+
+const containerStyle: CSSProperties = {
+  display: "flex",
+  padding: "var(--space-2)",
+  gap: 2,
+  borderBottom: "1px solid var(--color-border-subtle)",
+  flex: "0 0 auto",
+};
+
+const buttonStyle = (active: boolean): CSSProperties => ({
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+  height: 28,
+  padding: "0 8px",
+  borderRadius: "var(--radius-sm)",
+  background: active ? "var(--color-accent-dim)" : "transparent",
+  border: 0,
+  color: active ? "var(--color-accent)" : "var(--color-text-muted)",
+  cursor: "pointer",
+  fontSize: "var(--text-sm)",
+  fontWeight: "var(--fw-medium)" as CSSProperties["fontWeight"],
+  whiteSpace: "nowrap",
+  flex: "0 0 auto",
+});
+
+export const SectionSwitcher = ({
+  activeSection,
+  onSectionChange,
+}: SectionSwitcherProps) => (
+  <div data-testid="section-switcher" style={containerStyle}>
+    {SECTIONS.map((section) => {
+      const active = section.id === activeSection;
+      const Icon = section.icon;
+      return (
+        <button
+          key={section.id}
+          type="button"
+          data-testid={`section-btn-${section.id}`}
+          data-section-id={section.id}
+          data-active={String(active)}
+          onClick={() => onSectionChange(section.id)}
+          style={buttonStyle(active)}
+        >
+          <Icon size={14} aria-hidden="true" />
+          <span>{section.label}</span>
+        </button>
+      );
+    })}
+  </div>
+);

--- a/ui/tandem/src/features/sections/ui/StubBody.tsx
+++ b/ui/tandem/src/features/sections/ui/StubBody.tsx
@@ -1,0 +1,64 @@
+import type { CSSProperties } from "react";
+
+import type { SectionId } from "@/features/sections/ui/SectionSwitcher";
+
+type StubSection = Exclude<SectionId, "chat">;
+
+interface StubCopy {
+  title: string;
+  body: string;
+}
+
+const STUB_COPY: Record<StubSection, StubCopy> = {
+  projects: {
+    title: "Projects",
+    body: "Projects is shipping in v1.2. Until then, set your working directory via goose2's settings.",
+  },
+  memory: {
+    title: "Memory",
+    body: "Memory is shipping in v1.4.",
+  },
+  workflows: {
+    title: "Workflows",
+    body: "Workflows is shipping in v1.3.",
+  },
+  skills: {
+    title: "Skills",
+    body: "Skills is shipping in v1.2.",
+  },
+};
+
+interface StubBodyProps {
+  section: StubSection;
+}
+
+const containerStyle: CSSProperties = {
+  flex: 1,
+  minHeight: 0,
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "var(--space-6)",
+  textAlign: "center",
+  color: "var(--color-text-secondary)",
+  fontSize: "var(--text-sm)",
+  lineHeight: "var(--lh-normal)",
+};
+
+const titleStyle: CSSProperties = {
+  fontSize: "var(--text-lg)",
+  fontWeight: "var(--fw-semibold)" as CSSProperties["fontWeight"],
+  color: "var(--color-text)",
+  marginBottom: "var(--space-2)",
+};
+
+export const StubBody = ({ section }: StubBodyProps) => {
+  const copy = STUB_COPY[section];
+  return (
+    <div data-testid="stub-body" data-section={section} style={containerStyle}>
+      <div style={titleStyle}>{copy.title}</div>
+      <div>{copy.body}</div>
+    </div>
+  );
+};

--- a/ui/tandem/src/features/sections/ui/__tests__/SectionSwitcher.test.tsx
+++ b/ui/tandem/src/features/sections/ui/__tests__/SectionSwitcher.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { SectionSwitcher } from "@/features/sections/ui/SectionSwitcher";
+
+describe("SectionSwitcher", () => {
+  it("renders 5 buttons in order: chat, projects, memory, workflows, skills", () => {
+    render(<SectionSwitcher activeSection="chat" onSectionChange={() => {}} />);
+    const buttons = within(
+      screen.getByTestId("section-switcher"),
+    ).getAllByRole("button");
+    const ids = buttons.map((b) => b.getAttribute("data-section-id"));
+    expect(ids).toEqual(["chat", "projects", "memory", "workflows", "skills"]);
+  });
+
+  it("marks the active section with data-active=true and others false", () => {
+    render(
+      <SectionSwitcher
+        activeSection="workflows"
+        onSectionChange={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("section-btn-workflows")).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+    expect(screen.getByTestId("section-btn-chat")).toHaveAttribute(
+      "data-active",
+      "false",
+    );
+  });
+
+  it("clicking a button calls onSectionChange with that section id", async () => {
+    const user = userEvent.setup();
+    const onSectionChange = vi.fn();
+    render(
+      <SectionSwitcher
+        activeSection="chat"
+        onSectionChange={onSectionChange}
+      />,
+    );
+    await user.click(screen.getByTestId("section-btn-projects"));
+    expect(onSectionChange).toHaveBeenCalledWith("projects");
+  });
+
+  it("each button has its label as accessible name", () => {
+    render(<SectionSwitcher activeSection="chat" onSectionChange={() => {}} />);
+    expect(screen.getByRole("button", { name: "Chat" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Projects" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Memory" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Workflows" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Skills" })).toBeInTheDocument();
+  });
+});

--- a/ui/tandem/src/features/sections/ui/__tests__/StubBody.test.tsx
+++ b/ui/tandem/src/features/sections/ui/__tests__/StubBody.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { StubBody } from "@/features/sections/ui/StubBody";
+
+describe("StubBody", () => {
+  it("renders Projects copy with v1.2 target and goose2 workaround", () => {
+    render(<StubBody section="projects" />);
+    expect(screen.getByTestId("stub-body")).toHaveTextContent(
+      "Projects is shipping in v1.2. Until then, set your working directory via goose2's settings.",
+    );
+  });
+
+  it("renders Memory copy with v1.4 target", () => {
+    render(<StubBody section="memory" />);
+    expect(screen.getByTestId("stub-body")).toHaveTextContent(
+      "Memory is shipping in v1.4.",
+    );
+  });
+
+  it("renders Workflows copy with v1.3 target", () => {
+    render(<StubBody section="workflows" />);
+    expect(screen.getByTestId("stub-body")).toHaveTextContent(
+      "Workflows is shipping in v1.3.",
+    );
+  });
+
+  it("renders Skills copy with v1.2 target", () => {
+    render(<StubBody section="skills" />);
+    expect(screen.getByTestId("stub-body")).toHaveTextContent(
+      "Skills is shipping in v1.2.",
+    );
+  });
+
+  it("tags the rendered body with the section id", () => {
+    render(<StubBody section="memory" />);
+    expect(screen.getByTestId("stub-body")).toHaveAttribute(
+      "data-section",
+      "memory",
+    );
+  });
+});

--- a/ui/tandem/src/features/toasts/ToastViewport.tsx
+++ b/ui/tandem/src/features/toasts/ToastViewport.tsx
@@ -1,0 +1,67 @@
+import { X } from "lucide-react";
+
+import { useToastStore } from "@/features/toasts/toastStore";
+
+export const ToastViewport = () => {
+  const toasts = useToastStore((s) => s.toasts);
+  const dismissToast = useToastStore((s) => s.dismissToast);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      data-testid="toast-viewport"
+      style={{
+        position: "fixed",
+        top: 16,
+        right: 16,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        zIndex: 1000,
+        pointerEvents: "none",
+      }}
+    >
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          data-testid="toast"
+          role="status"
+          style={{
+            background: "var(--color-surface-raised)",
+            color: "var(--color-text)",
+            border: "1px solid var(--color-border)",
+            borderRadius: "var(--radius-md)",
+            boxShadow: "var(--shadow-2)",
+            padding: "8px 12px",
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            fontSize: "var(--text-sm)",
+            fontFamily: "var(--font-ui)",
+            pointerEvents: "auto",
+            minWidth: 240,
+          }}
+        >
+          <span style={{ flex: 1 }}>{toast.message}</span>
+          <button
+            type="button"
+            aria-label="Dismiss notification"
+            onClick={() => dismissToast(toast.id)}
+            style={{
+              background: "transparent",
+              border: 0,
+              padding: 2,
+              color: "var(--color-text-muted)",
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            <X size={14} aria-hidden="true" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/ui/tandem/src/features/toasts/__tests__/ToastViewport.test.tsx
+++ b/ui/tandem/src/features/toasts/__tests__/ToastViewport.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { useToastStore } from "@/features/toasts/toastStore";
+import { ToastViewport } from "@/features/toasts/ToastViewport";
+
+describe("ToastViewport", () => {
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [] });
+  });
+
+  afterEach(() => {
+    useToastStore.setState({ toasts: [] });
+  });
+
+  it("renders nothing when there are no toasts", () => {
+    render(<ToastViewport />);
+    expect(screen.queryByTestId("toast")).not.toBeInTheDocument();
+  });
+
+  it("renders a toast when one is added to the store", () => {
+    render(<ToastViewport />);
+    act(() => {
+      useToastStore.getState().addToast("Email — coming soon");
+    });
+    expect(screen.getByText("Email — coming soon")).toBeInTheDocument();
+  });
+
+  it("removes the toast from the DOM when dismissed via the close button", async () => {
+    const user = userEvent.setup();
+    render(<ToastViewport />);
+    act(() => {
+      useToastStore.getState().addToast("Settings — coming soon");
+    });
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(
+      screen.queryByText("Settings — coming soon"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/ui/tandem/src/features/toasts/__tests__/toastStore.test.ts
+++ b/ui/tandem/src/features/toasts/__tests__/toastStore.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+import { useToastStore } from "@/features/toasts/toastStore";
+
+describe("toastStore", () => {
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("addToast adds a toast with the given message", () => {
+    useToastStore.getState().addToast("Email — coming soon");
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].message).toBe("Email — coming soon");
+  });
+
+  it("addToast assigns a unique id to each toast", () => {
+    const { addToast } = useToastStore.getState();
+    addToast("a");
+    addToast("b");
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts).toHaveLength(2);
+    expect(toasts[0].id).not.toBe(toasts[1].id);
+  });
+
+  it("dismissToast removes the toast with that id", () => {
+    useToastStore.getState().addToast("first");
+    useToastStore.getState().addToast("second");
+    const [firstToast] = useToastStore.getState().toasts;
+    useToastStore.getState().dismissToast(firstToast.id);
+    const remaining = useToastStore.getState().toasts;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].message).toBe("second");
+  });
+
+  it("auto-dismisses a toast after the default duration", () => {
+    vi.useFakeTimers();
+    useToastStore.getState().addToast("transient");
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+    vi.advanceTimersByTime(3000);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+});

--- a/ui/tandem/src/features/toasts/toastStore.ts
+++ b/ui/tandem/src/features/toasts/toastStore.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+
+export interface Toast {
+  id: string;
+  message: string;
+}
+
+interface ToastState {
+  toasts: Toast[];
+  addToast: (message: string) => void;
+  dismissToast: (id: string) => void;
+}
+
+const TOAST_DURATION_MS = 3000;
+
+let nextId = 0;
+const makeId = () => `toast-${++nextId}-${Date.now()}`;
+
+export const useToastStore = create<ToastState>((set, get) => ({
+  toasts: [],
+  addToast: (message) => {
+    const id = makeId();
+    set((s) => ({ toasts: [...s.toasts, { id, message }] }));
+    setTimeout(() => {
+      if (get().toasts.some((t) => t.id === id)) {
+        get().dismissToast(id);
+      }
+    }, TOAST_DURATION_MS);
+  },
+  dismissToast: (id) => {
+    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+  },
+}));


### PR DESCRIPTION
## Summary

Phase 1b fills the four navigation zones left empty by Phase 1a. After this merges, the entire shell is navigable: clicking around the app routes correctly, non-Chat areas show "coming in vX.Y" stubs and toasts. The Main pane is still empty for Chat (lands in Phase 3a).

- **Ribbon** (`features/ribbon/ui/Ribbon.tsx`) — 44px rail, 5 app slots (Chat live + Email/Calendar/Projects/Editor stubs), Plugins/Settings at bottom. Lucide icons throughout, accent indicator on active Chat slot, non-live clicks fire `addToast("<Label> — coming soon")`.
- **LeftPane** (`features/left-pane/ui/LeftPane.tsx`) — collapsible 280↔52, search input filters `chatSessionStore` by title, `+` button (no-op for now — Phase 2 wires it). Hosts the SectionSwitcher and the Chat-section session list.
- **SectionSwitcher** (`features/sections/ui/SectionSwitcher.tsx`) — 5 buttons: Chat / Projects / Memory / Workflows / Skills. Active button visually distinct.
- **StubBody** (`features/sections/ui/StubBody.tsx`) — renders the version-targeted copy in the Main pane for non-Chat sections (Projects v1.2, Memory v1.4, Workflows v1.3, Skills v1.2).
- **RightPane** (`features/right-pane/ui/RightPane.tsx`) — collapsible 44↔320, starts collapsed, expanded view shows "Notes coming in v1.4".
- **Toasts** (`features/toasts/{toastStore,ToastViewport}`) — minimal in-house implementation (no library), Zustand store with 3s auto-dismiss, viewport mounted in AppShell.

AppShell wires the four zones together: tracks activeApp / section / leftCollapsed / rightCollapsed, renders StubBody in the Main pane for non-Chat sections, mounts ToastViewport.

## Acceptance gate (per issue #15)

- [x] Ribbon: 44px, Lucide icons, Chat active w/ accent + indicator bar, non-live click fires toast, Plugins/Settings toast
- [x] LeftPane: 280↔52 toggle, search filters session list, + button wired to no-op handler
- [x] SectionSwitcher: 5 buttons, active distinct, click changes section
- [x] StubBody: exact version-targeted copy for projects/memory/workflows/skills
- [x] RightPane: 44↔320 toggle, starts collapsed, "Notes coming in v1.4"

## Test plan

- [x] `pnpm test` — 24 files / 189 tests pass
- [x] `pnpm typecheck` — clean
- [x] Manual smoke test in browser (verified by Maxim)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)