### PR TITLE
Phase 2 - TabBar + tab persistence + sidebar reopen

### DIFF
--- a/ui/tandem/src/app/AppShell.tsx
+++ b/ui/tandem/src/app/AppShell.tsx
@@ -1,5 +1,6 @@
-import { useState, type CSSProperties } from "react";
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
 
+import { useAppStartup } from "@/app/hooks/useAppStartup";
 import { useConnectionStatus } from "@/features/connection/hooks/useConnectionStatus";
 import { LeftPane } from "@/features/left-pane/ui/LeftPane";
 import { Ribbon, type AppId } from "@/features/ribbon/ui/Ribbon";
@@ -8,6 +9,11 @@ import type { SectionId } from "@/features/sections/ui/SectionSwitcher";
 import { StubBody } from "@/features/sections/ui/StubBody";
 import { StatusBar } from "@/features/status/ui/StatusBar";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import { TabBar, type TabDescriptor } from "@/features/tabs/ui/TabBar";
+import {
+  DRAFT_TAB_PREFIX,
+  useTabsStore,
+} from "@/features/tabs/stores/tabsStore";
 import { ToastViewport } from "@/features/toasts/ToastViewport";
 
 const RIBBON_WIDTH = 44;
@@ -31,12 +37,42 @@ export const AppShell = () => {
   const [leftCollapsed, setLeftCollapsed] = useState(false);
   const [rightCollapsed, setRightCollapsed] = useState(true);
 
+  useAppStartup();
+
   const connectionStatus = useConnectionStatus();
   const sessions = useChatSessionStore((s) => s.sessions);
   const activeSessionId = useChatSessionStore((s) => s.activeSessionId);
   const activeSession = activeSessionId
     ? sessions.find((s) => s.id === activeSessionId)
     : undefined;
+
+  const tabOpenIds = useTabsStore((s) => s.openIds);
+  const tabActiveId = useTabsStore((s) => s.activeId);
+  const openTab = useTabsStore((s) => s.openTab);
+  const closeTab = useTabsStore((s) => s.closeTab);
+  const switchTab = useTabsStore((s) => s.switchTab);
+  const newTab = useTabsStore((s) => s.newTab);
+  const hydrateTabs = useTabsStore((s) => s.hydrate);
+
+  useEffect(() => {
+    hydrateTabs();
+  }, [hydrateTabs]);
+
+  const tabs = useMemo<TabDescriptor[]>(
+    () =>
+      tabOpenIds.map((id) => {
+        if (id.startsWith(DRAFT_TAB_PREFIX)) {
+          return { id, title: "New Chat" };
+        }
+        const session = sessions.find((s) => s.id === id);
+        return { id, title: session?.title ?? "Untitled" };
+      }),
+    [tabOpenIds, sessions],
+  );
+
+  const handleNewTab = () => {
+    newTab();
+  };
 
   const leftWidth = leftCollapsed ? LEFT_PANE_COLLAPSED : LEFT_PANE_EXPANDED;
   const rightWidth = rightCollapsed ? RIGHT_PANE_COLLAPSED : RIGHT_PANE_EXPANDED;
@@ -69,7 +105,8 @@ export const AppShell = () => {
           onToggleCollapsed={() => setLeftCollapsed((c) => !c)}
           activeSection={section}
           onSectionChange={setSection}
-          onNewChat={() => {}}
+          onNewChat={handleNewTab}
+          onSessionClick={openTab}
         />
       </div>
       <div
@@ -77,7 +114,17 @@ export const AppShell = () => {
         data-section={section}
         style={mainPaneStyle}
       >
-        {isStubSection && <StubBody section={section} />}
+        {isStubSection ? (
+          <StubBody section={section} />
+        ) : (
+          <TabBar
+            tabs={tabs}
+            activeId={tabActiveId}
+            onActivate={switchTab}
+            onClose={closeTab}
+            onNew={handleNewTab}
+          />
+        )}
       </div>
       <div style={{ gridArea: "right", overflow: "hidden" }}>
         <RightPane

--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -9,11 +9,17 @@ vi.mock("@/shared/api/acpConnection", () => ({
 import { AppShell } from "@/app/AppShell";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import { useToastStore } from "@/features/toasts/toastStore";
+import {
+  DRAFT_TAB_PREFIX,
+  useTabsStore,
+} from "@/features/tabs/stores/tabsStore";
 
 describe("AppShell", () => {
   beforeEach(() => {
     useChatSessionStore.setState({ sessions: [], activeSessionId: null });
     useToastStore.setState({ toasts: [] });
+    useTabsStore.setState({ openIds: [], activeId: null });
+    localStorage.clear();
   });
 
   it("renders all 5 zones", () => {
@@ -167,5 +173,125 @@ describe("AppShell", () => {
       "data-active",
       "true",
     );
+  });
+
+  it("renders the TabBar in the main pane on the chat section", () => {
+    render(<AppShell />);
+    expect(screen.getByTestId("tab-bar")).toBeInTheDocument();
+  });
+
+  it("does not render the TabBar when a stub section is active", async () => {
+    const user = userEvent.setup();
+    render(<AppShell />);
+    await user.click(screen.getByTestId("section-btn-projects"));
+    expect(screen.queryByTestId("tab-bar")).not.toBeInTheDocument();
+  });
+
+  it("clicking a session row in the LeftPane opens it as a tab", async () => {
+    const user = userEvent.setup();
+    act(() => {
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "abc",
+            title: "Existing chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+          },
+        ],
+      });
+    });
+    render(<AppShell />);
+    await user.click(screen.getByTestId("session-row-abc"));
+    expect(screen.getByTestId("tab-abc")).toHaveTextContent("Existing chat");
+    expect(screen.getByTestId("tab-abc")).toHaveAttribute("data-active", "true");
+  });
+
+  it("clicking the same session row again does not duplicate the tab", async () => {
+    const user = userEvent.setup();
+    act(() => {
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "abc",
+            title: "Existing chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+          },
+          {
+            id: "def",
+            title: "Other chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+          },
+        ],
+      });
+    });
+    render(<AppShell />);
+    await user.click(screen.getByTestId("session-row-abc"));
+    await user.click(screen.getByTestId("session-row-def"));
+    await user.click(screen.getByTestId("session-row-abc"));
+    // Both tabs present; abc focused
+    expect(screen.getAllByTestId(/^tab-(abc|def)$/)).toHaveLength(2);
+    expect(screen.getByTestId("tab-abc")).toHaveAttribute("data-active", "true");
+  });
+
+  it("clicking the LeftPane + button opens a new draft tab synchronously titled 'New Chat'", async () => {
+    const user = userEvent.setup();
+    render(<AppShell />);
+    await user.click(screen.getByTestId("left-pane-new-chat"));
+
+    const { openIds, activeId } = useTabsStore.getState();
+    expect(openIds).toHaveLength(1);
+    expect(openIds[0].startsWith(DRAFT_TAB_PREFIX)).toBe(true);
+    expect(activeId).toBe(openIds[0]);
+    expect(screen.getByTestId(`tab-${openIds[0]}`)).toHaveTextContent(
+      "New Chat",
+    );
+  });
+
+  it("clicking the TabBar + button also opens a new draft tab", async () => {
+    const user = userEvent.setup();
+    render(<AppShell />);
+    await user.click(screen.getByTestId("tab-new"));
+
+    const { openIds } = useTabsStore.getState();
+    expect(openIds).toHaveLength(1);
+    expect(openIds[0].startsWith(DRAFT_TAB_PREFIX)).toBe(true);
+  });
+
+  it("does not call any ACP API when creating a new tab (drafts are local-only)", async () => {
+    const user = userEvent.setup();
+    render(<AppShell />);
+    await user.click(screen.getByTestId("left-pane-new-chat"));
+    // chatSessionStore stays empty — no real session was created
+    expect(useChatSessionStore.getState().sessions).toHaveLength(0);
+  });
+
+  it("clicking a tab close button removes the tab but keeps the session in history", async () => {
+    const user = userEvent.setup();
+    act(() => {
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "abc",
+            title: "Existing chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+          },
+        ],
+      });
+    });
+    render(<AppShell />);
+    await user.click(screen.getByTestId("session-row-abc"));
+    expect(screen.getByTestId("tab-abc")).toBeInTheDocument();
+    await user.click(screen.getByTestId("tab-close-abc"));
+    expect(screen.queryByTestId("tab-abc")).not.toBeInTheDocument();
+    // Session still in history
+    expect(screen.getByTestId("session-row-abc")).toBeInTheDocument();
   });
 });

--- a/ui/tandem/src/app/hooks/useAppStartup.ts
+++ b/ui/tandem/src/app/hooks/useAppStartup.ts
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+
+// Phase 2 startup: hydrate the session list so the LeftPane history populates
+// from goose serve. Phase 3 will expand this to load provider inventory,
+// personas, etc. — see ui/goose2/src/app/hooks/useAppStartup.ts for the shape.
+export function useAppStartup(): void {
+  useEffect(() => {
+    void useChatSessionStore.getState().loadSessions();
+  }, []);
+}

--- a/ui/tandem/src/features/left-pane/ui/LeftPane.tsx
+++ b/ui/tandem/src/features/left-pane/ui/LeftPane.tsx
@@ -13,6 +13,7 @@ interface LeftPaneProps {
   activeSection: SectionId;
   onSectionChange: (id: SectionId) => void;
   onNewChat: () => void;
+  onSessionClick: (sessionId: string) => void;
 }
 
 const EXPANDED_WIDTH = 280;
@@ -114,6 +115,7 @@ export const LeftPane = ({
   activeSection,
   onSectionChange,
   onNewChat,
+  onSessionClick,
 }: LeftPaneProps) => {
   const [search, setSearch] = useState("");
   const sessions = useChatSessionStore((s) => s.sessions);
@@ -188,6 +190,15 @@ export const LeftPane = ({
                   <div
                     key={session.id}
                     data-testid={`session-row-${session.id}`}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => onSessionClick(session.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onSessionClick(session.id);
+                      }
+                    }}
                     style={sessionRowStyle}
                   >
                     {session.title}

--- a/ui/tandem/src/features/left-pane/ui/__tests__/LeftPane.test.tsx
+++ b/ui/tandem/src/features/left-pane/ui/__tests__/LeftPane.test.tsx
@@ -26,6 +26,7 @@ const noopProps = {
   activeSection: "chat" as const,
   onSectionChange: () => {},
   onNewChat: () => {},
+  onSessionClick: () => {},
 };
 
 describe("LeftPane", () => {
@@ -168,5 +169,20 @@ describe("LeftPane", () => {
       });
     });
     expect(screen.getAllByTestId(/session-row-/)).toHaveLength(2);
+  });
+
+  it("Chat section: clicking a session row calls onSessionClick with that session id", async () => {
+    const user = userEvent.setup();
+    const onSessionClick = vi.fn();
+    seedSessions(["Apple plans", "Banana split"]);
+    render(
+      <LeftPane
+        {...noopProps}
+        activeSection="chat"
+        onSessionClick={onSessionClick}
+      />,
+    );
+    await user.click(screen.getByTestId("session-row-s0"));
+    expect(onSessionClick).toHaveBeenCalledWith("s0");
   });
 });

--- a/ui/tandem/src/features/tabs/lib/__tests__/tabPersistence.test.ts
+++ b/ui/tandem/src/features/tabs/lib/__tests__/tabPersistence.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  TABS_STORAGE_KEY,
+  loadTabsState,
+  saveTabsState,
+} from "../tabPersistence";
+
+describe("tabPersistence", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("save → load round trip", () => {
+    it("returns saved openIds and activeId when all sessions still exist", () => {
+      saveTabsState({ openIds: ["s1", "s2"], activeId: "s2" });
+
+      const loaded = loadTabsState(() => true);
+
+      expect(loaded.openIds).toEqual(["s1", "s2"]);
+      expect(loaded.activeId).toBe("s2");
+    });
+
+    it("writes under the documented storage key", () => {
+      saveTabsState({ openIds: ["s1"], activeId: "s1" });
+      expect(localStorage.getItem(TABS_STORAGE_KEY)).not.toBeNull();
+    });
+  });
+
+  describe("load", () => {
+    it("returns empty state when nothing has been persisted", () => {
+      const loaded = loadTabsState(() => true);
+      expect(loaded).toEqual({ openIds: [], activeId: null });
+    });
+
+    it("silently drops persisted ids whose sessions no longer exist", () => {
+      saveTabsState({ openIds: ["s1", "stale", "s3"], activeId: "s3" });
+
+      const loaded = loadTabsState((id) => id !== "stale");
+
+      expect(loaded.openIds).toEqual(["s1", "s3"]);
+      expect(loaded.activeId).toBe("s3");
+    });
+
+    it("nulls activeId when the persisted active session no longer exists", () => {
+      saveTabsState({ openIds: ["s1", "stale"], activeId: "stale" });
+
+      const loaded = loadTabsState((id) => id !== "stale");
+
+      expect(loaded.openIds).toEqual(["s1"]);
+      expect(loaded.activeId).toBeNull();
+    });
+
+    it("returns empty state when stored value is malformed JSON", () => {
+      localStorage.setItem(TABS_STORAGE_KEY, "{not json");
+      expect(loadTabsState(() => true)).toEqual({
+        openIds: [],
+        activeId: null,
+      });
+    });
+  });
+});

--- a/ui/tandem/src/features/tabs/lib/__tests__/tabsReducer.test.ts
+++ b/ui/tandem/src/features/tabs/lib/__tests__/tabsReducer.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { initialTabsState, tabsReducer, type TabsState } from "../tabsReducer";
+
+describe("tabsReducer", () => {
+  describe("OPEN_TAB", () => {
+    it("adds the tab and makes it active when state is empty", () => {
+      const next = tabsReducer(initialTabsState, {
+        type: "OPEN_TAB",
+        sessionId: "s1",
+      });
+
+      expect(next.openIds).toEqual(["s1"]);
+      expect(next.activeId).toBe("s1");
+    });
+
+    it("focuses an already-open tab without duplicating it", () => {
+      const state: TabsState = { openIds: ["s1", "s2", "s3"], activeId: "s1" };
+      const next = tabsReducer(state, { type: "OPEN_TAB", sessionId: "s2" });
+
+      expect(next.openIds).toEqual(["s1", "s2", "s3"]);
+      expect(next.activeId).toBe("s2");
+    });
+  });
+
+  describe("CLOSE_TAB", () => {
+    it("removes a non-active tab and leaves activeId unchanged", () => {
+      const state: TabsState = { openIds: ["s1", "s2", "s3"], activeId: "s2" };
+      const next = tabsReducer(state, { type: "CLOSE_TAB", sessionId: "s3" });
+
+      expect(next.openIds).toEqual(["s1", "s2"]);
+      expect(next.activeId).toBe("s2");
+    });
+
+    it("returns the same state when closing a non-existent tab", () => {
+      const state: TabsState = { openIds: ["s1"], activeId: "s1" };
+      const next = tabsReducer(state, { type: "CLOSE_TAB", sessionId: "x" });
+      expect(next).toEqual(state);
+    });
+
+    it("falls back to the right neighbor when closing the active tab", () => {
+      const state: TabsState = { openIds: ["s1", "s2", "s3"], activeId: "s2" };
+      const next = tabsReducer(state, { type: "CLOSE_TAB", sessionId: "s2" });
+
+      expect(next.openIds).toEqual(["s1", "s3"]);
+      expect(next.activeId).toBe("s3");
+    });
+
+    it("falls back to the left neighbor when no right neighbor exists", () => {
+      const state: TabsState = { openIds: ["s1", "s2", "s3"], activeId: "s3" };
+      const next = tabsReducer(state, { type: "CLOSE_TAB", sessionId: "s3" });
+
+      expect(next.openIds).toEqual(["s1", "s2"]);
+      expect(next.activeId).toBe("s2");
+    });
+
+    it("clears activeId when closing the only tab", () => {
+      const state: TabsState = { openIds: ["s1"], activeId: "s1" };
+      const next = tabsReducer(state, { type: "CLOSE_TAB", sessionId: "s1" });
+
+      expect(next.openIds).toEqual([]);
+      expect(next.activeId).toBeNull();
+    });
+  });
+
+  describe("SWITCH_TAB", () => {
+    it("sets activeId when sessionId is in openIds", () => {
+      const state: TabsState = { openIds: ["s1", "s2"], activeId: "s1" };
+      const next = tabsReducer(state, { type: "SWITCH_TAB", sessionId: "s2" });
+
+      expect(next.activeId).toBe("s2");
+      expect(next.openIds).toEqual(["s1", "s2"]);
+    });
+
+    it("returns the same state when sessionId is not in openIds", () => {
+      const state: TabsState = { openIds: ["s1", "s2"], activeId: "s1" };
+      const next = tabsReducer(state, { type: "SWITCH_TAB", sessionId: "x" });
+      expect(next).toEqual(state);
+    });
+  });
+});

--- a/ui/tandem/src/features/tabs/lib/tabPersistence.ts
+++ b/ui/tandem/src/features/tabs/lib/tabPersistence.ts
@@ -1,0 +1,47 @@
+import { initialTabsState, type TabsState } from "./tabsReducer";
+
+export const TABS_STORAGE_KEY = "tandem.tabs.v1";
+
+interface PersistedShape {
+  openIds: string[];
+  activeId: string | null;
+}
+
+export function saveTabsState(state: TabsState): void {
+  const payload: PersistedShape = {
+    openIds: state.openIds,
+    activeId: state.activeId,
+  };
+  try {
+    localStorage.setItem(TABS_STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // localStorage unavailable / quota — silent: persistence is best-effort
+  }
+}
+
+export function loadTabsState(
+  sessionExists: (id: string) => boolean,
+): TabsState {
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(TABS_STORAGE_KEY);
+  } catch {
+    return initialTabsState;
+  }
+  if (raw == null) return initialTabsState;
+
+  let parsed: PersistedShape;
+  try {
+    parsed = JSON.parse(raw) as PersistedShape;
+  } catch {
+    return initialTabsState;
+  }
+
+  const openIds = (parsed.openIds ?? []).filter(sessionExists);
+  const activeId =
+    parsed.activeId != null && openIds.includes(parsed.activeId)
+      ? parsed.activeId
+      : null;
+
+  return { openIds, activeId };
+}

--- a/ui/tandem/src/features/tabs/lib/tabsReducer.ts
+++ b/ui/tandem/src/features/tabs/lib/tabsReducer.ts
@@ -1,0 +1,51 @@
+export interface TabsState {
+  openIds: string[];
+  activeId: string | null;
+}
+
+export type TabsAction =
+  | { type: "OPEN_TAB"; sessionId: string }
+  | { type: "CLOSE_TAB"; sessionId: string }
+  | { type: "SWITCH_TAB"; sessionId: string };
+
+export const initialTabsState: TabsState = {
+  openIds: [],
+  activeId: null,
+};
+
+export function tabsReducer(state: TabsState, action: TabsAction): TabsState {
+  switch (action.type) {
+    case "OPEN_TAB": {
+      const alreadyOpen = state.openIds.includes(action.sessionId);
+      return {
+        openIds: alreadyOpen
+          ? state.openIds
+          : [...state.openIds, action.sessionId],
+        activeId: action.sessionId,
+      };
+    }
+    case "CLOSE_TAB": {
+      const idx = state.openIds.indexOf(action.sessionId);
+      if (idx === -1) return state;
+      const openIds = state.openIds.filter((id) => id !== action.sessionId);
+      let activeId = state.activeId;
+      if (state.activeId === action.sessionId) {
+        if (openIds.length === 0) {
+          activeId = null;
+        } else if (idx < openIds.length) {
+          activeId = openIds[idx];
+        } else {
+          activeId = openIds[openIds.length - 1];
+        }
+      }
+      return { openIds, activeId };
+    }
+    case "SWITCH_TAB": {
+      if (!state.openIds.includes(action.sessionId)) return state;
+      if (state.activeId === action.sessionId) return state;
+      return { ...state, activeId: action.sessionId };
+    }
+    default:
+      return state;
+  }
+}

--- a/ui/tandem/src/features/tabs/stores/__tests__/tabsStore.test.ts
+++ b/ui/tandem/src/features/tabs/stores/__tests__/tabsStore.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import {
+  DRAFT_TAB_PREFIX,
+  useTabsStore,
+} from "@/features/tabs/stores/tabsStore";
+import { TABS_STORAGE_KEY } from "@/features/tabs/lib/tabPersistence";
+
+vi.mock("@/shared/api/acp", () => ({
+  acpCreateSession: vi.fn().mockResolvedValue({ sessionId: "new-session-id" }),
+  acpListSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/shared/api/acpApi", () => ({
+  archiveSession: vi.fn().mockResolvedValue(undefined),
+  unarchiveSession: vi.fn().mockResolvedValue(undefined),
+  renameSession: vi.fn().mockResolvedValue(undefined),
+  updateSessionProject: vi.fn().mockResolvedValue(undefined),
+}));
+
+function resetAll() {
+  localStorage.clear();
+  useChatSessionStore.setState({
+    sessions: [],
+    activeSessionId: null,
+    isLoading: false,
+    hasHydratedSessions: false,
+    contextPanelOpenBySession: {},
+    activeWorkspaceBySession: {},
+  });
+  useTabsStore.setState({ openIds: [], activeId: null });
+}
+
+function seedSession(id: string) {
+  useChatSessionStore.getState().addSession({
+    id,
+    acpSessionId: id,
+    title: `Title ${id}`,
+    createdAt: "",
+    updatedAt: "",
+    messageCount: 0,
+  });
+}
+
+describe("tabsStore", () => {
+  beforeEach(() => {
+    resetAll();
+  });
+
+  describe("openTab", () => {
+    it("adds the tab and makes it active", () => {
+      seedSession("s1");
+      useTabsStore.getState().openTab("s1");
+
+      const { openIds, activeId } = useTabsStore.getState();
+      expect(openIds).toEqual(["s1"]);
+      expect(activeId).toBe("s1");
+    });
+
+    it("focuses an already-open tab without duplicating", () => {
+      seedSession("s1");
+      seedSession("s2");
+      useTabsStore.getState().openTab("s1");
+      useTabsStore.getState().openTab("s2");
+      useTabsStore.getState().openTab("s1");
+
+      const { openIds, activeId } = useTabsStore.getState();
+      expect(openIds).toEqual(["s1", "s2"]);
+      expect(activeId).toBe("s1");
+    });
+
+    it("persists state to localStorage on each mutation", () => {
+      seedSession("s1");
+      useTabsStore.getState().openTab("s1");
+
+      const raw = localStorage.getItem(TABS_STORAGE_KEY);
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw!)).toEqual({ openIds: ["s1"], activeId: "s1" });
+    });
+  });
+
+  describe("closeTab", () => {
+    it("removes the tab and persists the new state", () => {
+      seedSession("s1");
+      seedSession("s2");
+      useTabsStore.getState().openTab("s1");
+      useTabsStore.getState().openTab("s2");
+      useTabsStore.getState().closeTab("s2");
+
+      expect(useTabsStore.getState().openIds).toEqual(["s1"]);
+      expect(useTabsStore.getState().activeId).toBe("s1");
+      expect(JSON.parse(localStorage.getItem(TABS_STORAGE_KEY)!)).toEqual({
+        openIds: ["s1"],
+        activeId: "s1",
+      });
+    });
+  });
+
+  describe("switchTab", () => {
+    it("changes activeId when sessionId is open", () => {
+      seedSession("s1");
+      seedSession("s2");
+      useTabsStore.getState().openTab("s1");
+      useTabsStore.getState().openTab("s2");
+      useTabsStore.getState().switchTab("s1");
+
+      expect(useTabsStore.getState().activeId).toBe("s1");
+    });
+  });
+
+  describe("newTab", () => {
+    it("opens a draft tab synchronously without touching ACP or chatSessionStore", () => {
+      const draftId = useTabsStore.getState().newTab();
+
+      expect(draftId.startsWith(DRAFT_TAB_PREFIX)).toBe(true);
+      // No ACP sessions created (chatSessionStore stays empty)
+      expect(useChatSessionStore.getState().sessions).toHaveLength(0);
+      // tabs store opened the draft and made it active
+      const { openIds, activeId } = useTabsStore.getState();
+      expect(openIds).toEqual([draftId]);
+      expect(activeId).toBe(draftId);
+    });
+
+    it("each newTab call produces a distinct draft id", () => {
+      const a = useTabsStore.getState().newTab();
+      const b = useTabsStore.getState().newTab();
+      expect(a).not.toBe(b);
+      expect(useTabsStore.getState().openIds).toEqual([a, b]);
+    });
+  });
+
+  describe("hydrate", () => {
+    it("restores persisted tabs whose sessions still exist", () => {
+      seedSession("s1");
+      seedSession("s2");
+      localStorage.setItem(
+        TABS_STORAGE_KEY,
+        JSON.stringify({ openIds: ["s1", "s2"], activeId: "s2" }),
+      );
+
+      useTabsStore.getState().hydrate();
+
+      const { openIds, activeId } = useTabsStore.getState();
+      expect(openIds).toEqual(["s1", "s2"]);
+      expect(activeId).toBe("s2");
+    });
+
+    it("silently drops persisted tabs whose sessions no longer exist", () => {
+      seedSession("s1");
+      // s2 was persisted but no longer in chatSessionStore
+      localStorage.setItem(
+        TABS_STORAGE_KEY,
+        JSON.stringify({ openIds: ["s1", "s2"], activeId: "s2" }),
+      );
+
+      useTabsStore.getState().hydrate();
+
+      const { openIds, activeId } = useTabsStore.getState();
+      expect(openIds).toEqual(["s1"]);
+      expect(activeId).toBeNull();
+    });
+
+    it("preserves persisted draft tabs (they have no backing chatSession)", () => {
+      const draftId = `${DRAFT_TAB_PREFIX}abc-123`;
+      localStorage.setItem(
+        TABS_STORAGE_KEY,
+        JSON.stringify({ openIds: [draftId], activeId: draftId }),
+      );
+
+      useTabsStore.getState().hydrate();
+
+      const { openIds, activeId } = useTabsStore.getState();
+      expect(openIds).toEqual([draftId]);
+      expect(activeId).toBe(draftId);
+    });
+  });
+});

--- a/ui/tandem/src/features/tabs/stores/tabsStore.ts
+++ b/ui/tandem/src/features/tabs/stores/tabsStore.ts
@@ -1,0 +1,71 @@
+import { create } from "zustand";
+
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import {
+  loadTabsState,
+  saveTabsState,
+} from "@/features/tabs/lib/tabPersistence";
+import {
+  initialTabsState,
+  tabsReducer,
+  type TabsAction,
+  type TabsState,
+} from "@/features/tabs/lib/tabsReducer";
+
+interface TabsActions {
+  openTab: (sessionId: string) => void;
+  closeTab: (sessionId: string) => void;
+  switchTab: (sessionId: string) => void;
+  newTab: () => string;
+  hydrate: () => void;
+}
+
+export type TabsStore = TabsState & TabsActions;
+
+// A draft tab id is recognized by this prefix; persistence treats it as
+// always-existing on hydrate so freshly opened drafts survive a reload until
+// Phase 3 promotes them into real ACP sessions on first message.
+export const DRAFT_TAB_PREFIX = "draft-";
+
+function isDraftId(id: string): boolean {
+  return id.startsWith(DRAFT_TAB_PREFIX);
+}
+
+function sessionOrDraftExists(id: string): boolean {
+  if (isDraftId(id)) return true;
+  return useChatSessionStore
+    .getState()
+    .sessions.some((session) => session.id === id);
+}
+
+export const useTabsStore = create<TabsStore>((set, get) => {
+  const dispatch = (action: TabsAction) => {
+    const next = tabsReducer(
+      { openIds: get().openIds, activeId: get().activeId },
+      action,
+    );
+    set(next);
+    saveTabsState(next);
+  };
+
+  return {
+    ...initialTabsState,
+
+    openTab: (sessionId) => dispatch({ type: "OPEN_TAB", sessionId }),
+
+    closeTab: (sessionId) => dispatch({ type: "CLOSE_TAB", sessionId }),
+
+    switchTab: (sessionId) => dispatch({ type: "SWITCH_TAB", sessionId }),
+
+    newTab: () => {
+      const draftId = `${DRAFT_TAB_PREFIX}${crypto.randomUUID()}`;
+      dispatch({ type: "OPEN_TAB", sessionId: draftId });
+      return draftId;
+    },
+
+    hydrate: () => {
+      const restored = loadTabsState(sessionOrDraftExists);
+      set(restored);
+    },
+  };
+});

--- a/ui/tandem/src/features/tabs/ui/TabBar.tsx
+++ b/ui/tandem/src/features/tabs/ui/TabBar.tsx
@@ -1,0 +1,170 @@
+import { MessageSquare, Plus, X } from "lucide-react";
+import type { CSSProperties, KeyboardEvent, MouseEvent } from "react";
+
+export interface TabDescriptor {
+  id: string;
+  title: string;
+}
+
+interface TabBarProps {
+  tabs: TabDescriptor[];
+  activeId: string | null;
+  onActivate: (id: string) => void;
+  onClose: (id: string) => void;
+  onNew: () => void;
+}
+
+const tabBarStyle: CSSProperties = {
+  height: "var(--tabbar-height)",
+  flex: "0 0 var(--tabbar-height)",
+  display: "flex",
+  alignItems: "stretch",
+  background: "var(--color-bg)",
+  borderBottom: "1px solid var(--color-border-subtle)",
+  paddingLeft: "var(--space-1)",
+  paddingRight: "var(--space-1)",
+};
+
+const tabStripStyle: CSSProperties = {
+  display: "flex",
+  flex: 1,
+  alignItems: "stretch",
+  overflowX: "auto",
+  overflowY: "hidden",
+  minWidth: 0,
+  scrollbarWidth: "none",
+};
+
+const tabStyle = (active: boolean): CSSProperties => ({
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+  padding: "0 10px",
+  height: "calc(var(--tabbar-height) - 4px)",
+  margin: "2px 2px 0",
+  borderRadius: "var(--radius-sm) var(--radius-sm) 0 0",
+  background: active ? "var(--color-canvas)" : "transparent",
+  color: active ? "var(--color-text)" : "var(--color-text-muted)",
+  fontSize: "var(--text-sm)",
+  cursor: "pointer",
+  position: "relative",
+  flex: "0 1 200px",
+  minWidth: 0,
+  border: 0,
+  maxWidth: 220,
+  transition: "background var(--dur-fast) var(--ease-out)",
+});
+
+const tabTitleStyle: CSSProperties = {
+  flex: 1,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  fontSize: "var(--text-sm)",
+  textAlign: "left",
+};
+
+const tabIconStyle = (active: boolean): CSSProperties => ({
+  flex: "0 0 auto",
+  color: active ? "var(--color-accent)" : "var(--color-text-muted)",
+  display: "flex",
+});
+
+const tabCloseStyle: CSSProperties = {
+  width: 16,
+  height: 16,
+  borderRadius: "var(--radius-xs)",
+  background: "transparent",
+  border: 0,
+  color: "var(--color-text-muted)",
+  cursor: "pointer",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  flex: "0 0 auto",
+};
+
+const newButtonStyle: CSSProperties = {
+  alignSelf: "center",
+  marginLeft: 4,
+  width: 24,
+  height: 24,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  background: "transparent",
+  border: 0,
+  borderRadius: "var(--radius-sm)",
+  color: "var(--color-text-muted)",
+  cursor: "pointer",
+  flex: "0 0 auto",
+};
+
+export const TabBar = ({
+  tabs,
+  activeId,
+  onActivate,
+  onClose,
+  onNew,
+}: TabBarProps) => {
+  const handleClose = (id: string) => (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onClose(id);
+  };
+
+  const handleTabKeyDown =
+    (id: string) => (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onActivate(id);
+      }
+    };
+
+  return (
+    <div data-testid="tab-bar" style={tabBarStyle}>
+      <div style={tabStripStyle}>
+        {tabs.map((tab) => {
+          const active = tab.id === activeId;
+          return (
+            <div
+              key={tab.id}
+              role="tab"
+              tabIndex={0}
+              aria-selected={active}
+              data-testid={`tab-${tab.id}`}
+              data-active={String(active)}
+              onClick={() => onActivate(tab.id)}
+              onKeyDown={handleTabKeyDown(tab.id)}
+              style={tabStyle(active)}
+              title={tab.title}
+            >
+              <span style={tabIconStyle(active)}>
+                <MessageSquare size={12} aria-hidden="true" />
+              </span>
+              <span style={tabTitleStyle}>{tab.title}</span>
+              <button
+                type="button"
+                data-testid={`tab-close-${tab.id}`}
+                aria-label={`Close ${tab.title}`}
+                onClick={handleClose(tab.id)}
+                style={tabCloseStyle}
+              >
+                <X size={11} aria-hidden="true" />
+              </button>
+            </div>
+          );
+        })}
+        <button
+          type="button"
+          data-testid="tab-new"
+          aria-label="New tab"
+          title="New tab"
+          onClick={onNew}
+          style={newButtonStyle}
+        >
+          <Plus size={14} aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/ui/tandem/src/features/tabs/ui/__tests__/TabBar.test.tsx
+++ b/ui/tandem/src/features/tabs/ui/__tests__/TabBar.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { TabBar, type TabDescriptor } from "@/features/tabs/ui/TabBar";
+
+const tabs: TabDescriptor[] = [
+  { id: "s1", title: "Onboarding doc" },
+  { id: "s2", title: "Bug triage" },
+];
+
+const noopProps = {
+  tabs,
+  activeId: "s1",
+  onActivate: () => {},
+  onClose: () => {},
+  onNew: () => {},
+};
+
+describe("TabBar", () => {
+  it("renders a row at tabbar height", () => {
+    render(<TabBar {...noopProps} />);
+    expect(screen.getByTestId("tab-bar")).toHaveStyle({
+      height: "var(--tabbar-height)",
+    });
+  });
+
+  it("renders a tab for each open session with its title", () => {
+    render(<TabBar {...noopProps} />);
+    expect(screen.getByTestId("tab-s1")).toHaveTextContent("Onboarding doc");
+    expect(screen.getByTestId("tab-s2")).toHaveTextContent("Bug triage");
+  });
+
+  it("marks the active tab with data-active='true'", () => {
+    render(<TabBar {...noopProps} activeId="s2" />);
+    expect(screen.getByTestId("tab-s1")).toHaveAttribute(
+      "data-active",
+      "false",
+    );
+    expect(screen.getByTestId("tab-s2")).toHaveAttribute("data-active", "true");
+  });
+
+  it("invokes onActivate when a tab is clicked", async () => {
+    const onActivate = vi.fn();
+    render(<TabBar {...noopProps} onActivate={onActivate} />);
+    await userEvent.click(screen.getByTestId("tab-s2"));
+    expect(onActivate).toHaveBeenCalledWith("s2");
+  });
+
+  it("invokes onClose (and not onActivate) when the close button is clicked", async () => {
+    const onActivate = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <TabBar {...noopProps} onActivate={onActivate} onClose={onClose} />,
+    );
+    await userEvent.click(screen.getByTestId("tab-close-s2"));
+    expect(onClose).toHaveBeenCalledWith("s2");
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+
+  it("invokes onNew when the + button is clicked", async () => {
+    const onNew = vi.fn();
+    render(<TabBar {...noopProps} onNew={onNew} />);
+    await userEvent.click(screen.getByTestId("tab-new"));
+    expect(onNew).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Multi-tab system inside the Main pane (resolves #16):

- **`tabsReducer`** — pure reducer for `OPEN_TAB` / `CLOSE_TAB` / `SWITCH_TAB`, with right-then-left neighbor fallback when closing the active tab.
- **`TabPersistenceService`** — round-trips `{openIds, activeId}` through localStorage under `tandem.tabs.v1`. On `load`, stale ids (whose sessions no longer exist) are silently dropped.
- **`TabBar`** — matches `design/project/Chat.jsx` + `app.css` pixel-for-pixel; Lucide icons only, horizontal overflow scroll, per-tab close button, `+` button.
- **`useTabsStore`** — Zustand wrapper that dispatches reducer actions and persists on every mutation.
- **`LeftPane`** — adds `onSessionClick`; clicking a session row opens or focuses a tab (keyboard-accessible).
- **`AppShell`** — hydrates tabs on mount; renders `TabBar` only on the chat section; wires both `+` buttons (LeftPane and TabBar).
- **`useAppStartup`** — minimal startup hook that calls `chatSessionStore.loadSessions()` so the LeftPane history populates from existing goose sessions.

### Draft tabs (deferred ACP)

The `+` button creates a **draft tab** with a local UUID (prefix `draft-`) without calling ACP. Phase 3 will promote drafts to real ACP sessions on first message via the existing `sessionTracker.prepareSession` pattern (local id → goose id on demand).

This was a deliberate scope decision after observing that `acpCreateSession`'s `setProvider(goose)` call blocks for ~130 seconds on a fresh install while goose serve initializes its provider — making the user-facing `+` action unusable. Provider inventory loading + the no-providers banner land in Phase 3 per `Notes/Tandem v1.0 Plan.md`. Drafts cleanly separate Phase 2 (tab UX) from Phase 3 (chat wiring) and match the goose2 internal model where local session ids are mapped to goose session ids lazily.

### Acceptance gate

- [x] Tab open / close / switch updates state (reducer + tabsStore + AppShell tests)
- [x] localStorage roundtrip on reload restores open tabs + active tab (persistence + tabsStore tests)
- [x] Closing a tab does NOT delete the session from `chatSessionStore` (AppShell test)
- [x] LeftPane session history backed by `chatSessionStore`, click reopens / focuses (Phase 1b + this PR)

### Stats

- 13 files, +940 lines
- 29 new tab-specific tests; 229 total tests green
- `tsc --noEmit` clean
- Manual smoke pass: open/switch/close/persist all work instantly

## Test plan

- [x] `pnpm test` — 229/229 pass
- [x] `pnpm typecheck` — clean
- [x] Manual: click `+` in LeftPane header → tab appears instantly
- [x] Manual: click `+` in TabBar → tab appears instantly
- [x] Manual: switch between tabs (active state changes)
- [x] Manual: close tab via `×` button (right-then-left neighbor focus)
- [x] Manual: `Ctrl+R` reload → open draft tabs restored
- [x] Manual (requires real sessions): click LeftPane session row → reopens / focuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)