### PR TITLE
Phase 3a part 1 — chat empty state, composer, draft→session, basic timeline

### DIFF
--- a/ui/tandem/src/app/AppShell.tsx
+++ b/ui/tandem/src/app/AppShell.tsx
@@ -9,6 +9,7 @@ import type { SectionId } from "@/features/sections/ui/SectionSwitcher";
 import { StubBody } from "@/features/sections/ui/StubBody";
 import { StatusBar } from "@/features/status/ui/StatusBar";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import { ChatPane } from "@/features/chat/ui/ChatPane";
 import { TabBar, type TabDescriptor } from "@/features/tabs/ui/TabBar";
 import {
   DRAFT_TAB_PREFIX,
@@ -117,13 +118,16 @@ export const AppShell = () => {
         {isStubSection ? (
           <StubBody section={section} />
         ) : (
-          <TabBar
-            tabs={tabs}
-            activeId={tabActiveId}
-            onActivate={switchTab}
-            onClose={closeTab}
-            onNew={handleNewTab}
-          />
+          <>
+            <TabBar
+              tabs={tabs}
+              activeId={tabActiveId}
+              onActivate={switchTab}
+              onClose={closeTab}
+              onNew={handleNewTab}
+            />
+            <ChatPane />
+          </>
         )}
       </div>
       <div style={{ gridArea: "right", overflow: "hidden" }}>

--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -317,6 +317,16 @@ describe("AppShell", () => {
         /Good evening/i,
       );
     });
+
+    it("renders a multi-line textarea composer inside the empty state", () => {
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      useTabsStore.setState({ openIds: [draftId], activeId: draftId });
+
+      render(<AppShell />);
+
+      const composer = screen.getByTestId("chat-composer-input");
+      expect(composer.tagName).toBe("TEXTAREA");
+    });
   });
 
   it("clicking a tab close button removes the tab but keeps the session in history", async () => {

--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -49,7 +49,7 @@ function seedTabs(openIds: string[], activeId: string | null) {
 describe("AppShell", () => {
   beforeEach(() => {
     useChatSessionStore.setState({ sessions: [], activeSessionId: null });
-    useChatStore.setState({ messagesBySession: {} });
+    useChatStore.setState({ messagesBySession: {}, sessionStateById: {} });
     useToastStore.setState({ toasts: [] });
     useTabsStore.setState({ openIds: [], activeId: null });
     localStorage.clear();
@@ -453,6 +453,91 @@ describe("AppShell", () => {
       expect(assistantAvatar).toHaveAttribute("data-role", "assistant");
       // Assistant avatar is an icon (svg), not text
       expect(assistantAvatar.querySelector("svg")).toBeInTheDocument();
+    });
+
+    it("shows a typing indicator while the assistant is generating", () => {
+      seedTabs(["sess-1"], "sess-1");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-1",
+            title: "Existing chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+          },
+        ],
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-1": [
+            {
+              id: "u1",
+              role: "user",
+              created: 1,
+              content: [{ type: "text", text: "hi" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+        sessionStateById: {
+          "sess-1": {
+            chatState: "streaming",
+            tokenState: {
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+              accumulatedInput: 0,
+              accumulatedOutput: 0,
+              accumulatedTotal: 0,
+              contextLimit: 0,
+            },
+            hasUsageSnapshot: false,
+            streamingMessageId: null,
+            pendingAssistantProviderId: null,
+            error: null,
+            hasUnread: false,
+          },
+        },
+      });
+
+      render(<AppShell />);
+
+      expect(screen.getByTestId("chat-typing-indicator")).toBeInTheDocument();
+    });
+
+    it("hides the typing indicator when chatState is idle", () => {
+      seedTabs(["sess-1"], "sess-1");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-1",
+            title: "Existing chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+          },
+        ],
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-1": [
+            {
+              id: "u1",
+              role: "user",
+              created: 1,
+              content: [{ type: "text", text: "hi" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+      });
+
+      render(<AppShell />);
+
+      expect(
+        screen.queryByTestId("chat-typing-indicator"),
+      ).not.toBeInTheDocument();
     });
 
     it("first send from a draft tab creates a session, replaces the tab id, and hard-swaps to the timeline", async () => {

--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -8,6 +8,7 @@ vi.mock("@/shared/api/acpConnection", () => ({
 
 import { AppShell } from "@/app/AppShell";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import { useChatStore } from "@/features/chat/stores/chatStore";
 import { useToastStore } from "@/features/toasts/toastStore";
 import {
   DRAFT_TAB_PREFIX,
@@ -17,6 +18,7 @@ import {
 describe("AppShell", () => {
   beforeEach(() => {
     useChatSessionStore.setState({ sessions: [], activeSessionId: null });
+    useChatStore.setState({ messagesBySession: {} });
     useToastStore.setState({ toasts: [] });
     useTabsStore.setState({ openIds: [], activeId: null });
     localStorage.clear();
@@ -269,6 +271,52 @@ describe("AppShell", () => {
     await user.click(screen.getByTestId("left-pane-new-chat"));
     // chatSessionStore stays empty — no real session was created
     expect(useChatSessionStore.getState().sessions).toHaveLength(0);
+  });
+
+  describe("chat empty state", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("shows the empty-state greeting in the main pane when the active tab is a draft with no messages", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 3, 27, 10, 0, 0)); // 10:00 AM local
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      useTabsStore.setState({ openIds: [draftId], activeId: draftId });
+
+      render(<AppShell />);
+
+      const empty = screen.getByTestId("chat-empty-state");
+      expect(empty).toBeInTheDocument();
+      expect(empty).toHaveTextContent(/Good morning/i);
+      expect(empty).toHaveTextContent(/What are we working on\?/i);
+    });
+
+    it("uses 'afternoon' between 12:00 and 17:59", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 3, 27, 14, 0, 0));
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      useTabsStore.setState({ openIds: [draftId], activeId: draftId });
+
+      render(<AppShell />);
+
+      expect(screen.getByTestId("chat-empty-state")).toHaveTextContent(
+        /Good afternoon/i,
+      );
+    });
+
+    it("uses 'evening' from 18:00 onward", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 3, 27, 20, 0, 0));
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      useTabsStore.setState({ openIds: [draftId], activeId: draftId });
+
+      render(<AppShell />);
+
+      expect(screen.getByTestId("chat-empty-state")).toHaveTextContent(
+        /Good evening/i,
+      );
+    });
   });
 
   it("clicking a tab close button removes the tab but keeps the session in history", async () => {

--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -366,6 +366,95 @@ describe("AppShell", () => {
       expect(composer.tagName).toBe("TEXTAREA");
     });
 
+    it("renders the timeline (no empty state) when the active tab has messages", () => {
+      seedTabs(["sess-1"], "sess-1");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-1",
+            title: "Existing chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 2,
+          },
+        ],
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-1": [
+            {
+              id: "u1",
+              role: "user",
+              created: 1,
+              content: [{ type: "text", text: "hi" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+            {
+              id: "a1",
+              role: "assistant",
+              created: 2,
+              content: [{ type: "text", text: "hello back" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+      });
+
+      render(<AppShell />);
+
+      expect(screen.queryByTestId("chat-empty-state")).not.toBeInTheDocument();
+      const timeline = screen.getByTestId("chat-timeline");
+      expect(timeline).toHaveTextContent("hi");
+      expect(timeline).toHaveTextContent("hello back");
+    });
+
+    it("renders user initials on user messages and an assistant icon on assistant messages", () => {
+      seedTabs(["sess-1"], "sess-1");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-1",
+            title: "Existing chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 2,
+          },
+        ],
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-1": [
+            {
+              id: "u1",
+              role: "user",
+              created: 1,
+              content: [{ type: "text", text: "hi" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+            {
+              id: "a1",
+              role: "assistant",
+              created: 2,
+              content: [{ type: "text", text: "hello back" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+      });
+
+      render(<AppShell />);
+
+      const userAvatar = screen.getByTestId("chat-avatar-u1");
+      expect(userAvatar).toHaveAttribute("data-role", "user");
+      // DEFAULT_USER_NAME = "Maxim" → initials "M"
+      expect(userAvatar).toHaveTextContent("M");
+
+      const assistantAvatar = screen.getByTestId("chat-avatar-a1");
+      expect(assistantAvatar).toHaveAttribute("data-role", "assistant");
+      // Assistant avatar is an icon (svg), not text
+      expect(assistantAvatar.querySelector("svg")).toBeInTheDocument();
+    });
+
     it("first send from a draft tab creates a session, replaces the tab id, and hard-swaps to the timeline", async () => {
       const user = userEvent.setup();
       const draftId = `${DRAFT_TAB_PREFIX}abc`;

--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -1,9 +1,29 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 vi.mock("@/shared/api/acpConnection", () => ({
   getClient: vi.fn(() => new Promise(() => {})),
+}));
+
+const { mockAcpCreateSession, mockAcpSendMessage, mockResolvePath } =
+  vi.hoisted(() => ({
+    mockAcpCreateSession: vi.fn(),
+    mockAcpSendMessage: vi.fn(),
+    mockResolvePath: vi.fn(),
+  }));
+
+vi.mock("@/shared/api/acp", async (importActual) => {
+  const actual = await importActual<typeof import("@/shared/api/acp")>();
+  return {
+    ...actual,
+    acpCreateSession: mockAcpCreateSession,
+    acpSendMessage: mockAcpSendMessage,
+  };
+});
+
+vi.mock("@/shared/api/pathResolver", () => ({
+  resolvePath: mockResolvePath,
 }));
 
 import { AppShell } from "@/app/AppShell";
@@ -14,6 +34,17 @@ import {
   DRAFT_TAB_PREFIX,
   useTabsStore,
 } from "@/features/tabs/stores/tabsStore";
+import { TABS_STORAGE_KEY } from "@/features/tabs/lib/tabPersistence";
+
+function seedTabs(openIds: string[], activeId: string | null) {
+  // Persist + setState so the AppShell hydrate effect restores the same shape
+  // instead of clobbering test setup with an empty localStorage read.
+  localStorage.setItem(
+    TABS_STORAGE_KEY,
+    JSON.stringify({ openIds, activeId }),
+  );
+  useTabsStore.setState({ openIds, activeId });
+}
 
 describe("AppShell", () => {
   beforeEach(() => {
@@ -22,6 +53,13 @@ describe("AppShell", () => {
     useToastStore.setState({ toasts: [] });
     useTabsStore.setState({ openIds: [], activeId: null });
     localStorage.clear();
+    mockAcpCreateSession.mockReset();
+    mockAcpSendMessage.mockReset();
+    mockResolvePath.mockReset();
+    mockResolvePath.mockResolvedValue({
+      path: "/home/test/.goose/artifacts",
+    });
+    mockAcpSendMessage.mockResolvedValue(undefined);
   });
 
   it("renders all 5 zones", () => {
@@ -282,7 +320,7 @@ describe("AppShell", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date(2026, 3, 27, 10, 0, 0)); // 10:00 AM local
       const draftId = `${DRAFT_TAB_PREFIX}abc`;
-      useTabsStore.setState({ openIds: [draftId], activeId: draftId });
+      seedTabs([draftId], draftId);
 
       render(<AppShell />);
 
@@ -296,7 +334,7 @@ describe("AppShell", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date(2026, 3, 27, 14, 0, 0));
       const draftId = `${DRAFT_TAB_PREFIX}abc`;
-      useTabsStore.setState({ openIds: [draftId], activeId: draftId });
+      seedTabs([draftId], draftId);
 
       render(<AppShell />);
 
@@ -309,7 +347,7 @@ describe("AppShell", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date(2026, 3, 27, 20, 0, 0));
       const draftId = `${DRAFT_TAB_PREFIX}abc`;
-      useTabsStore.setState({ openIds: [draftId], activeId: draftId });
+      seedTabs([draftId], draftId);
 
       render(<AppShell />);
 
@@ -320,12 +358,63 @@ describe("AppShell", () => {
 
     it("renders a multi-line textarea composer inside the empty state", () => {
       const draftId = `${DRAFT_TAB_PREFIX}abc`;
-      useTabsStore.setState({ openIds: [draftId], activeId: draftId });
+      seedTabs([draftId], draftId);
 
       render(<AppShell />);
 
       const composer = screen.getByTestId("chat-composer-input");
       expect(composer.tagName).toBe("TEXTAREA");
+    });
+
+    it("first send from a draft tab creates a session, replaces the tab id, and hard-swaps to the timeline", async () => {
+      const user = userEvent.setup();
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      seedTabs([draftId], draftId);
+
+      mockAcpCreateSession.mockResolvedValue({
+        sessionId: "real-session-id",
+      });
+
+      render(<AppShell />);
+
+      const input = screen.getByTestId("chat-composer-input");
+      await user.type(input, "hello world");
+      await user.keyboard("{Enter}");
+
+      // Empty state gone, timeline showing the user's message
+      await waitFor(
+        () => {
+          expect(mockAcpCreateSession).toHaveBeenCalled();
+        },
+        { timeout: 3000 },
+      );
+      await waitFor(
+        () => {
+          expect(screen.queryByTestId("chat-empty-state")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 },
+      );
+      const timeline = screen.getByTestId("chat-timeline");
+      expect(timeline).toHaveTextContent("hello world");
+
+      // Tab swapped to real session id
+      const { openIds, activeId } = useTabsStore.getState();
+      expect(openIds).toEqual(["real-session-id"]);
+      expect(activeId).toBe("real-session-id");
+
+      // Session in store, message persisted
+      const sessions = useChatSessionStore.getState().sessions;
+      expect(sessions.map((s) => s.id)).toContain("real-session-id");
+      const msgs =
+        useChatStore.getState().messagesBySession["real-session-id"] ?? [];
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].role).toBe("user");
+
+      // ACP prompt sent
+      expect(mockAcpSendMessage).toHaveBeenCalledWith(
+        "real-session-id",
+        "hello world",
+      );
     });
   });
 

--- a/ui/tandem/src/features/chat/hooks/useChat.ts
+++ b/ui/tandem/src/features/chat/hooks/useChat.ts
@@ -1,0 +1,54 @@
+import { useCallback } from "react";
+
+import { acpSendMessage } from "@/shared/api/acp";
+import { resolvePath } from "@/shared/api/pathResolver";
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import { useChatStore } from "@/features/chat/stores/chatStore";
+import {
+  DRAFT_TAB_PREFIX,
+  useTabsStore,
+} from "@/features/tabs/stores/tabsStore";
+import { createUserMessage } from "@/shared/types/messages";
+
+const isDraftId = (id: string) => id.startsWith(DRAFT_TAB_PREFIX);
+
+async function defaultWorkingDir(): Promise<string> {
+  const { path } = await resolvePath({ parts: ["~", ".goose", "artifacts"] });
+  return path;
+}
+
+export interface UseChatResult {
+  send: (text: string) => Promise<void>;
+  hasMessages: boolean;
+}
+
+export function useChat(tabId: string | null): UseChatResult {
+  const messages = useChatStore((s) =>
+    tabId ? s.messagesBySession[tabId] : undefined,
+  );
+
+  const send = useCallback(
+    async (text: string) => {
+      if (!tabId) return;
+
+      let sessionId = tabId;
+      if (isDraftId(tabId)) {
+        const workingDir = await defaultWorkingDir();
+        const session = await useChatSessionStore
+          .getState()
+          .createSession({ workingDir });
+        sessionId = session.id;
+        useTabsStore.getState().replaceTab(tabId, sessionId);
+      }
+
+      useChatStore.getState().addMessage(sessionId, createUserMessage(text));
+      await acpSendMessage(sessionId, text);
+    },
+    [tabId],
+  );
+
+  return {
+    send,
+    hasMessages: (messages?.length ?? 0) > 0,
+  };
+}

--- a/ui/tandem/src/features/chat/lib/timeOfDay.ts
+++ b/ui/tandem/src/features/chat/lib/timeOfDay.ts
@@ -1,0 +1,9 @@
+export type TimeOfDay = "morning" | "afternoon" | "evening";
+
+export function getTimeOfDay(date: Date = new Date()): TimeOfDay {
+  const hour = date.getHours();
+  if (hour < 5) return "evening";
+  if (hour < 12) return "morning";
+  if (hour < 18) return "afternoon";
+  return "evening";
+}

--- a/ui/tandem/src/features/chat/lib/userIdentity.ts
+++ b/ui/tandem/src/features/chat/lib/userIdentity.ts
@@ -1,0 +1,3 @@
+// v1.0 placeholder. Real OS-username resolution lands when a Tauri command
+// for it is wired (deferred — see issue #17 follow-ups).
+export const DEFAULT_USER_NAME = "Maxim";

--- a/ui/tandem/src/features/chat/lib/userIdentity.ts
+++ b/ui/tandem/src/features/chat/lib/userIdentity.ts
@@ -1,3 +1,10 @@
 // v1.0 placeholder. Real OS-username resolution lands when a Tauri command
 // for it is wired (deferred — see issue #17 follow-ups).
 export const DEFAULT_USER_NAME = "Maxim";
+
+export function getUserInitials(name: string = DEFAULT_USER_NAME): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0]![0]!.toUpperCase();
+  return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase();
+}

--- a/ui/tandem/src/features/chat/ui/ChatPane.tsx
+++ b/ui/tandem/src/features/chat/ui/ChatPane.tsx
@@ -1,0 +1,5 @@
+import { EmptyState } from "@/features/chat/ui/EmptyState";
+
+export const ChatPane = () => {
+  return <EmptyState />;
+};

--- a/ui/tandem/src/features/chat/ui/ChatPane.tsx
+++ b/ui/tandem/src/features/chat/ui/ChatPane.tsx
@@ -1,5 +1,34 @@
+import { useChat } from "@/features/chat/hooks/useChat";
+import { Composer } from "@/features/chat/ui/Composer";
 import { EmptyState } from "@/features/chat/ui/EmptyState";
+import { Timeline } from "@/features/chat/ui/Timeline";
+import { useTabsStore } from "@/features/tabs/stores/tabsStore";
 
 export const ChatPane = () => {
-  return <EmptyState />;
+  const activeTabId = useTabsStore((s) => s.activeId);
+  const { send, hasMessages } = useChat(activeTabId);
+
+  if (!activeTabId || !hasMessages) {
+    return <EmptyState onSend={send} />;
+  }
+
+  return (
+    <div
+      data-testid="chat-active"
+      style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}
+    >
+      <Timeline sessionId={activeTabId} />
+      <div
+        style={{
+          padding: "8px 16px 16px",
+          borderTop: "1px solid var(--color-border-subtle)",
+          background: "var(--color-canvas)",
+          display: "flex",
+          justifyContent: "center",
+        }}
+      >
+        <Composer onSend={send} />
+      </div>
+    </div>
+  );
 };

--- a/ui/tandem/src/features/chat/ui/Composer.tsx
+++ b/ui/tandem/src/features/chat/ui/Composer.tsx
@@ -1,0 +1,55 @@
+export interface ComposerProps {
+  placeholder?: string;
+}
+
+export const Composer = ({
+  placeholder = "Ask anything, or paste a file…",
+}: ComposerProps) => {
+  return (
+    <div
+      data-testid="chat-composer"
+      style={{
+        width: "100%",
+        maxWidth: 720,
+        background: "var(--color-surface)",
+        border: "1px solid var(--color-border-subtle)",
+        borderRadius: 12,
+        padding: 12,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      <textarea
+        data-testid="chat-composer-input"
+        placeholder={placeholder}
+        rows={2}
+        style={{
+          width: "100%",
+          minHeight: 44,
+          background: "transparent",
+          color: "var(--color-text)",
+          border: "none",
+          outline: "none",
+          resize: "none",
+          fontFamily: "var(--font-ui)",
+          fontSize: 14,
+          lineHeight: 1.5,
+        }}
+      />
+      <div
+        data-testid="chat-composer-footer"
+        style={{
+          height: 28,
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          color: "var(--color-text-muted)",
+          fontSize: 12,
+        }}
+      >
+        {/* Stub footer — real chips land in Phase 3b */}
+      </div>
+    </div>
+  );
+};

--- a/ui/tandem/src/features/chat/ui/Composer.tsx
+++ b/ui/tandem/src/features/chat/ui/Composer.tsx
@@ -1,10 +1,26 @@
+import { useState, type KeyboardEvent } from "react";
+
 export interface ComposerProps {
   placeholder?: string;
+  onSend?: (text: string) => void;
 }
 
 export const Composer = ({
   placeholder = "Ask anything, or paste a file…",
+  onSend,
 }: ComposerProps) => {
+  const [value, setValue] = useState("");
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      const trimmed = value.trim();
+      if (!trimmed) return;
+      onSend?.(trimmed);
+      setValue("");
+    }
+  };
+
   return (
     <div
       data-testid="chat-composer"
@@ -24,6 +40,9 @@ export const Composer = ({
         data-testid="chat-composer-input"
         placeholder={placeholder}
         rows={2}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
         style={{
           width: "100%",
           minHeight: 44,

--- a/ui/tandem/src/features/chat/ui/EmptyState.tsx
+++ b/ui/tandem/src/features/chat/ui/EmptyState.tsx
@@ -1,0 +1,38 @@
+import { getTimeOfDay } from "@/features/chat/lib/timeOfDay";
+import { DEFAULT_USER_NAME } from "@/features/chat/lib/userIdentity";
+
+export interface EmptyStateProps {
+  name?: string;
+}
+
+export const EmptyState = ({ name = DEFAULT_USER_NAME }: EmptyStateProps) => {
+  const tod = getTimeOfDay();
+  return (
+    <div
+      data-testid="chat-empty-state"
+      style={{
+        flex: 1,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 16,
+        padding: 32,
+      }}
+    >
+      <div
+        style={{
+          fontFamily: "var(--font-reading)",
+          fontSize: 28,
+          color: "var(--color-text)",
+          textAlign: "center",
+          lineHeight: 1.4,
+        }}
+      >
+        Good {tod}, <span style={{ color: "var(--color-accent)" }}>{name}</span>.
+        <br />
+        <em>What are we working on?</em>
+      </div>
+    </div>
+  );
+};

--- a/ui/tandem/src/features/chat/ui/EmptyState.tsx
+++ b/ui/tandem/src/features/chat/ui/EmptyState.tsx
@@ -1,5 +1,6 @@
 import { getTimeOfDay } from "@/features/chat/lib/timeOfDay";
 import { DEFAULT_USER_NAME } from "@/features/chat/lib/userIdentity";
+import { Composer } from "@/features/chat/ui/Composer";
 
 export interface EmptyStateProps {
   name?: string;
@@ -16,7 +17,7 @@ export const EmptyState = ({ name = DEFAULT_USER_NAME }: EmptyStateProps) => {
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-        gap: 16,
+        gap: 24,
         padding: 32,
       }}
     >
@@ -33,6 +34,7 @@ export const EmptyState = ({ name = DEFAULT_USER_NAME }: EmptyStateProps) => {
         <br />
         <em>What are we working on?</em>
       </div>
+      <Composer />
     </div>
   );
 };

--- a/ui/tandem/src/features/chat/ui/EmptyState.tsx
+++ b/ui/tandem/src/features/chat/ui/EmptyState.tsx
@@ -4,9 +4,13 @@ import { Composer } from "@/features/chat/ui/Composer";
 
 export interface EmptyStateProps {
   name?: string;
+  onSend?: (text: string) => void;
 }
 
-export const EmptyState = ({ name = DEFAULT_USER_NAME }: EmptyStateProps) => {
+export const EmptyState = ({
+  name = DEFAULT_USER_NAME,
+  onSend,
+}: EmptyStateProps) => {
   const tod = getTimeOfDay();
   return (
     <div
@@ -34,7 +38,7 @@ export const EmptyState = ({ name = DEFAULT_USER_NAME }: EmptyStateProps) => {
         <br />
         <em>What are we working on?</em>
       </div>
-      <Composer />
+      <Composer onSend={onSend} />
     </div>
   );
 };

--- a/ui/tandem/src/features/chat/ui/Timeline.tsx
+++ b/ui/tandem/src/features/chat/ui/Timeline.tsx
@@ -1,0 +1,48 @@
+import { useChatStore } from "@/features/chat/stores/chatStore";
+import { getTextContent, type Message } from "@/shared/types/messages";
+
+export interface TimelineProps {
+  sessionId: string;
+}
+
+export const Timeline = ({ sessionId }: TimelineProps) => {
+  const messages = useChatStore(
+    (s) => s.messagesBySession[sessionId] ?? EMPTY_MESSAGES,
+  );
+
+  return (
+    <div
+      data-testid="chat-timeline"
+      style={{
+        flex: 1,
+        overflow: "auto",
+        padding: 16,
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+      }}
+    >
+      {messages.map((m) => (
+        <MessageRow key={m.id} message={m} />
+      ))}
+    </div>
+  );
+};
+
+const EMPTY_MESSAGES: Message[] = [];
+
+const MessageRow = ({ message }: { message: Message }) => {
+  return (
+    <div
+      data-testid={`chat-message-${message.role}`}
+      data-message-id={message.id}
+      style={{
+        fontFamily: "var(--font-reading)",
+        color: "var(--color-text)",
+        whiteSpace: "pre-wrap",
+      }}
+    >
+      {getTextContent(message)}
+    </div>
+  );
+};

--- a/ui/tandem/src/features/chat/ui/Timeline.tsx
+++ b/ui/tandem/src/features/chat/ui/Timeline.tsx
@@ -1,9 +1,14 @@
+import { Sparkles } from "lucide-react";
+
 import { useChatStore } from "@/features/chat/stores/chatStore";
+import { getUserInitials } from "@/features/chat/lib/userIdentity";
 import { getTextContent, type Message } from "@/shared/types/messages";
 
 export interface TimelineProps {
   sessionId: string;
 }
+
+const EMPTY_MESSAGES: Message[] = [];
 
 export const Timeline = ({ sessionId }: TimelineProps) => {
   const messages = useChatStore(
@@ -29,7 +34,33 @@ export const Timeline = ({ sessionId }: TimelineProps) => {
   );
 };
 
-const EMPTY_MESSAGES: Message[] = [];
+const AVATAR_SIZE = 28;
+
+const Avatar = ({ message }: { message: Message }) => {
+  const isUser = message.role === "user";
+  return (
+    <div
+      data-testid={`chat-avatar-${message.id}`}
+      data-role={message.role}
+      style={{
+        width: AVATAR_SIZE,
+        height: AVATAR_SIZE,
+        borderRadius: "50%",
+        background: isUser ? "var(--color-accent)" : "var(--color-raised)",
+        color: "var(--color-text)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily: "var(--font-ui)",
+        fontSize: 12,
+        fontWeight: 600,
+        flexShrink: 0,
+      }}
+    >
+      {isUser ? getUserInitials() : <Sparkles size={14} />}
+    </div>
+  );
+};
 
 const MessageRow = ({ message }: { message: Message }) => {
   return (
@@ -37,12 +68,23 @@ const MessageRow = ({ message }: { message: Message }) => {
       data-testid={`chat-message-${message.role}`}
       data-message-id={message.id}
       style={{
-        fontFamily: "var(--font-reading)",
-        color: "var(--color-text)",
-        whiteSpace: "pre-wrap",
+        display: "flex",
+        gap: 10,
+        alignItems: "flex-start",
       }}
     >
-      {getTextContent(message)}
+      <Avatar message={message} />
+      <div
+        style={{
+          fontFamily: "var(--font-reading)",
+          color: "var(--color-text)",
+          whiteSpace: "pre-wrap",
+          lineHeight: 1.55,
+          paddingTop: 4,
+        }}
+      >
+        {getTextContent(message)}
+      </div>
     </div>
   );
 };

--- a/ui/tandem/src/features/chat/ui/Timeline.tsx
+++ b/ui/tandem/src/features/chat/ui/Timeline.tsx
@@ -3,6 +3,7 @@ import { Sparkles } from "lucide-react";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import { getUserInitials } from "@/features/chat/lib/userIdentity";
 import { getTextContent, type Message } from "@/shared/types/messages";
+import type { ChatState } from "@/shared/types/chat";
 
 export interface TimelineProps {
   sessionId: string;
@@ -10,10 +11,19 @@ export interface TimelineProps {
 
 const EMPTY_MESSAGES: Message[] = [];
 
+const ASSISTANT_BUSY_STATES: ReadonlySet<ChatState> = new Set([
+  "thinking",
+  "streaming",
+]);
+
 export const Timeline = ({ sessionId }: TimelineProps) => {
   const messages = useChatStore(
     (s) => s.messagesBySession[sessionId] ?? EMPTY_MESSAGES,
   );
+  const chatState = useChatStore(
+    (s) => s.sessionStateById[sessionId]?.chatState ?? "idle",
+  );
+  const showTypingIndicator = ASSISTANT_BUSY_STATES.has(chatState);
 
   return (
     <div
@@ -30,9 +40,61 @@ export const Timeline = ({ sessionId }: TimelineProps) => {
       {messages.map((m) => (
         <MessageRow key={m.id} message={m} />
       ))}
+      {showTypingIndicator && <TypingIndicator />}
     </div>
   );
 };
+
+const TypingIndicator = () => (
+  <div
+    data-testid="chat-typing-indicator"
+    style={{
+      display: "flex",
+      gap: 10,
+      alignItems: "center",
+      color: "var(--color-text-muted)",
+    }}
+  >
+    <div
+      style={{
+        width: 28,
+        height: 28,
+        borderRadius: "50%",
+        background: "var(--color-raised)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <Sparkles size={14} />
+    </div>
+    <span
+      style={{
+        display: "inline-flex",
+        gap: 3,
+        fontSize: 18,
+        letterSpacing: 1,
+      }}
+    >
+      <Dot delay={0} />
+      <Dot delay={0.15} />
+      <Dot delay={0.3} />
+    </span>
+  </div>
+);
+
+const Dot = ({ delay }: { delay: number }) => (
+  <span
+    style={{
+      width: 6,
+      height: 6,
+      borderRadius: "50%",
+      background: "currentColor",
+      animation: `tandem-typing 1s infinite ${delay}s`,
+      opacity: 0.3,
+    }}
+  />
+);
 
 const AVATAR_SIZE = 28;
 

--- a/ui/tandem/src/features/chat/ui/__tests__/Composer.test.tsx
+++ b/ui/tandem/src/features/chat/ui/__tests__/Composer.test.tsx
@@ -59,4 +59,20 @@ describe("Composer", () => {
 
     expect(onSend).not.toHaveBeenCalled();
   });
+
+  it("inserts a newline on Shift+Enter and does not submit", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<Composer onSend={onSend} />);
+    const input = screen.getByTestId(
+      "chat-composer-input",
+    ) as HTMLTextAreaElement;
+
+    await user.type(input, "line one");
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+    await user.type(input, "line two");
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(input.value).toBe("line one\nline two");
+  });
 });

--- a/ui/tandem/src/features/chat/ui/__tests__/Composer.test.tsx
+++ b/ui/tandem/src/features/chat/ui/__tests__/Composer.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { Composer } from "@/features/chat/ui/Composer";
+
+describe("Composer", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls onSend with the trimmed text when Enter is pressed", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<Composer onSend={onSend} />);
+    const input = screen.getByTestId("chat-composer-input");
+
+    await user.type(input, "  hello world  ");
+    await user.keyboard("{Enter}");
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend).toHaveBeenCalledWith("hello world");
+  });
+
+  it("clears the input after submitting", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<Composer onSend={onSend} />);
+    const input = screen.getByTestId(
+      "chat-composer-input",
+    ) as HTMLTextAreaElement;
+
+    await user.type(input, "hi");
+    await user.keyboard("{Enter}");
+
+    expect(input.value).toBe("");
+  });
+
+  it("does not call onSend when input is empty", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<Composer onSend={onSend} />);
+    const input = screen.getByTestId("chat-composer-input");
+
+    input.focus();
+    await user.keyboard("{Enter}");
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("does not call onSend when input is whitespace only", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<Composer onSend={onSend} />);
+    const input = screen.getByTestId("chat-composer-input");
+
+    await user.type(input, "    ");
+    await user.keyboard("{Enter}");
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});

--- a/ui/tandem/src/features/tabs/lib/tabsReducer.ts
+++ b/ui/tandem/src/features/tabs/lib/tabsReducer.ts
@@ -6,7 +6,8 @@ export interface TabsState {
 export type TabsAction =
   | { type: "OPEN_TAB"; sessionId: string }
   | { type: "CLOSE_TAB"; sessionId: string }
-  | { type: "SWITCH_TAB"; sessionId: string };
+  | { type: "SWITCH_TAB"; sessionId: string }
+  | { type: "REPLACE_TAB"; oldId: string; newId: string };
 
 export const initialTabsState: TabsState = {
   openIds: [],
@@ -44,6 +45,26 @@ export function tabsReducer(state: TabsState, action: TabsAction): TabsState {
       if (!state.openIds.includes(action.sessionId)) return state;
       if (state.activeId === action.sessionId) return state;
       return { ...state, activeId: action.sessionId };
+    }
+    case "REPLACE_TAB": {
+      const idx = state.openIds.indexOf(action.oldId);
+      if (idx === -1) return state;
+      // If newId is already open elsewhere, just drop the old slot.
+      if (state.openIds.includes(action.newId)) {
+        const openIds = state.openIds.filter((id) => id !== action.oldId);
+        return {
+          openIds,
+          activeId:
+            state.activeId === action.oldId ? action.newId : state.activeId,
+        };
+      }
+      const openIds = [...state.openIds];
+      openIds[idx] = action.newId;
+      return {
+        openIds,
+        activeId:
+          state.activeId === action.oldId ? action.newId : state.activeId,
+      };
     }
     default:
       return state;

--- a/ui/tandem/src/features/tabs/stores/tabsStore.ts
+++ b/ui/tandem/src/features/tabs/stores/tabsStore.ts
@@ -17,6 +17,7 @@ interface TabsActions {
   closeTab: (sessionId: string) => void;
   switchTab: (sessionId: string) => void;
   newTab: () => string;
+  replaceTab: (oldId: string, newId: string) => void;
   hydrate: () => void;
 }
 
@@ -62,6 +63,9 @@ export const useTabsStore = create<TabsStore>((set, get) => {
       dispatch({ type: "OPEN_TAB", sessionId: draftId });
       return draftId;
     },
+
+    replaceTab: (oldId, newId) =>
+      dispatch({ type: "REPLACE_TAB", oldId, newId }),
 
     hydrate: () => {
       const restored = loadTabsState(sessionOrDraftExists);


### PR DESCRIPTION
## Summary

Part 1 of three for [#17](https://github.com/larkinmaxim/tandem/issues/17). Built TDD-style as 7 vertical slices (one red→green→commit per slice). Each commit's message names the slice; full plan + slice-level progress tracked in [the issue's pinned comment](https://github.com/larkinmaxim/tandem/issues/17#issuecomment-4324463898).

- **Empty state:** centered greeting `Good {tod}, {name}. *What are we working on?*` with the Tandem accent on the name.
- **Composer:** multi-line `<textarea>`, **Enter** submits trimmed text, **Shift+Enter** newline, no-op on empty/whitespace, stub footer.
- **Draft→session promotion:** new `useChat` hook + `REPLACE_TAB` action on `tabsStore`. First send from a `draft-…` tab resolves `~/.goose/artifacts` via `pathResolver`, calls `chatSessionStore.createSession`, swaps the draft id for the real session id, persists the user message, fires `acpSendMessage` — UI hard-swaps from empty state to timeline.
- **Timeline:** `Timeline` + `MessageRow` with per-message `Avatar` (user initials from `getUserInitials`, assistant `Sparkles` icon).
- **Typing indicator:** animated dots when active session's `chatState ∈ {thinking, streaming}`.

## Acceptance criteria mapped (from #17)

| Criterion | Status |
|---|---|
| Centered greeting with time-of-day word | ✅ slice 1 |
| Composer below greeting | ✅ slice 2 |
| Hard-swap to timeline on first send | ✅ slice 5 |
| Multi-line auto-grow textarea | ✅ slice 2 (multi-line; auto-grow not yet — adequate for v1.0) |
| Enter submits / Shift+Enter newline | ✅ slices 3 + 4 |
| Footer is a stub strip | ✅ slice 2 (placeholder div; real chips in Part 2 / Phase 3b) |
| User initials / assistant icon | ✅ slice 6 |
| Typing indicator | ✅ slice 7 |
| File attach button → ACP payload | ⏳ Part 2 (slice 8) |
| Stream assistant in real time | ⚠️ visually wired (slice 7); **runtime wire missing** — `setNotificationHandler` must land in `useAppStartup`. Filed as slice 7b in Part 2. |
| Active persona/agent name visible | ⏳ Part 2 (slice 9) |
| Auto-approve permission requests | ✅ inherited unchanged from frozen `acpConnection.ts` |
| All 50 ai-element renderers + restyle 12 always-on | ⏳ Part 3 |

## Files

- `src/features/chat/lib/timeOfDay.ts` — pure `getTimeOfDay(date?)` → `morning|afternoon|evening`.
- `src/features/chat/lib/userIdentity.ts` — `DEFAULT_USER_NAME = "Maxim"` + `getUserInitials()`. Single point to swap when OS-username gets wired.
- `src/features/chat/ui/EmptyState.tsx`, `Composer.tsx`, `ChatPane.tsx`, `Timeline.tsx`.
- `src/features/chat/hooks/useChat.ts` — thin Tandem-specific (~50 LOC) instead of porting goose2's 489-line `useChat.ts`.
- `src/features/tabs/lib/tabsReducer.ts` + `stores/tabsStore.ts` — new `REPLACE_TAB` action / `replaceTab(oldId, newId)` method, position-preserving, dedup-aware.
- `src/app/AppShell.tsx` — renders `<ChatPane />` below `<TabBar />` in chat section.
- `src/app/__tests__/AppShell.test.tsx` — 6 new integration tests + a `seedTabs` helper that pre-populates `localStorage` so the AppShell hydrate effect doesn't clobber test setup.
- `src/features/chat/ui/__tests__/Composer.test.tsx` — 5 unit tests for composer behavior.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` green — **243/243** passing
- [ ] Manual smoke: `pnpm tauri dev`, open Tandem, click "+ New Chat", greeting renders with time-of-day, type + Enter sends to ACP, response streams (will only render once Part 2's slice 7b wires `setNotificationHandler`).

## Branching note

Phase 3a is splitting into three PRs: this part (foundation), then `tandem/feat/v1.0-phase-3a-wireup` (slices 7b–11), then `tandem/feat/v1.0-phase-3a-renderers` (slices 12–15). Issue #17 stays open until all three merge. Tag `tandem/v1.0` after all of Phase 3 is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)