### PR TITLE
Phase 3a part 2 — wire-up, attachments, persona, providers banner

### DIFF
--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -28,15 +28,37 @@ vi.mock("@/shared/api/pathResolver", () => ({
 }));
 
 import { AppShell } from "@/app/AppShell";
+import type { ProviderInventoryEntryDto } from "@aaif/goose-sdk";
+
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import { useToastStore } from "@/features/toasts/toastStore";
 import { useAgentStore } from "@/features/agents/stores/agentStore";
+import { useProviderInventoryStore } from "@/features/providers/stores/providerInventoryStore";
 import {
   DRAFT_TAB_PREFIX,
   useTabsStore,
 } from "@/features/tabs/stores/tabsStore";
 import { TABS_STORAGE_KEY } from "@/features/tabs/lib/tabPersistence";
+
+function makeConfiguredEntry(
+  providerId = "openai",
+): ProviderInventoryEntryDto {
+  return {
+    providerId,
+    providerName: providerId,
+    description: "",
+    defaultModel: "gpt-4",
+    configured: true,
+    providerType: "Builtin",
+    configKeys: [],
+    setupSteps: [],
+    supportsRefresh: false,
+    refreshing: false,
+    models: [],
+    stale: false,
+  };
+}
 
 function seedTabs(openIds: string[], activeId: string | null) {
   // Persist + setState so the AppShell hydrate effect restores the same shape
@@ -54,6 +76,12 @@ describe("AppShell", () => {
     useChatStore.setState({ messagesBySession: {}, sessionStateById: {} });
     useToastStore.setState({ toasts: [] });
     useAgentStore.setState({ personas: [] });
+    useProviderInventoryStore.setState({
+      entries: new Map<string, ProviderInventoryEntryDto>([
+        ["openai", makeConfiguredEntry("openai")],
+      ]),
+      loading: false,
+    });
     useTabsStore.setState({ openIds: [], activeId: null });
     localStorage.clear();
     mockAcpCreateSession.mockReset();
@@ -810,6 +838,58 @@ describe("AppShell", () => {
       expect(typeof data).toBe("string");
       expect(data.length).toBeGreaterThan(0);
       expect(mimeType).toBe("image/png");
+    });
+  });
+
+  describe("providers banner (slice 11)", () => {
+    it("renders a banner with the warning copy when no providers are configured", () => {
+      useProviderInventoryStore.setState({
+        entries: new Map<string, ProviderInventoryEntryDto>(),
+      });
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      seedTabs([draftId], draftId);
+
+      render(<AppShell />);
+
+      const banner = screen.getByTestId("chat-providers-banner");
+      expect(banner).toBeInTheDocument();
+      expect(banner).toHaveTextContent(/no providers configured/i);
+      expect(banner).toHaveTextContent(/open goose2/i);
+    });
+
+    it("disables the composer textarea and attach button when no providers are configured", () => {
+      useProviderInventoryStore.setState({
+        entries: new Map<string, ProviderInventoryEntryDto>(),
+      });
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      seedTabs([draftId], draftId);
+
+      render(<AppShell />);
+
+      const input = screen.getByTestId("chat-composer-input");
+      expect(input).toBeDisabled();
+      const attach = screen.getByTestId("chat-composer-attach");
+      expect(attach).toBeDisabled();
+    });
+
+    it("does not render the banner when at least one entry has configured: true", () => {
+      useProviderInventoryStore.setState({
+        entries: new Map<string, ProviderInventoryEntryDto>([
+          [
+            "openai",
+            { ...makeConfiguredEntry("openai"), configured: false },
+          ],
+          ["anthropic", makeConfiguredEntry("anthropic")],
+        ]),
+      });
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      seedTabs([draftId], draftId);
+
+      render(<AppShell />);
+
+      expect(
+        screen.queryByTestId("chat-providers-banner"),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -31,6 +31,7 @@ import { AppShell } from "@/app/AppShell";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import { useToastStore } from "@/features/toasts/toastStore";
+import { useAgentStore } from "@/features/agents/stores/agentStore";
 import {
   DRAFT_TAB_PREFIX,
   useTabsStore,
@@ -52,6 +53,7 @@ describe("AppShell", () => {
     useChatSessionStore.setState({ sessions: [], activeSessionId: null });
     useChatStore.setState({ messagesBySession: {}, sessionStateById: {} });
     useToastStore.setState({ toasts: [] });
+    useAgentStore.setState({ personas: [] });
     useTabsStore.setState({ openIds: [], activeId: null });
     localStorage.clear();
     mockAcpCreateSession.mockReset();
@@ -454,6 +456,129 @@ describe("AppShell", () => {
       expect(assistantAvatar).toHaveAttribute("data-role", "assistant");
       // Assistant avatar is an icon (svg), not text
       expect(assistantAvatar.querySelector("svg")).toBeInTheDocument();
+    });
+
+    it("shows the persona's displayName on assistant messages when the session has a matching personaId", () => {
+      seedTabs(["sess-1"], "sess-1");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-1",
+            title: "Existing chat",
+            personaId: "p1",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+          },
+        ],
+      });
+      useAgentStore.setState({
+        personas: [
+          {
+            id: "p1",
+            displayName: "Senior Engineer",
+            systemPrompt: "",
+            isBuiltin: true,
+            createdAt: "",
+            updatedAt: "",
+          },
+        ],
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-1": [
+            {
+              id: "a1",
+              role: "assistant",
+              created: 1,
+              content: [{ type: "text", text: "hello back" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+      });
+
+      render(<AppShell />);
+
+      expect(screen.getByTestId("chat-message-persona-a1")).toHaveTextContent(
+        "Senior Engineer",
+      );
+    });
+
+    it("does not render the persona header above user messages", () => {
+      seedTabs(["sess-1"], "sess-1");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-1",
+            title: "Existing chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 2,
+          },
+        ],
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-1": [
+            {
+              id: "u1",
+              role: "user",
+              created: 1,
+              content: [{ type: "text", text: "hi" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+            {
+              id: "a1",
+              role: "assistant",
+              created: 2,
+              content: [{ type: "text", text: "hello back" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+      });
+
+      render(<AppShell />);
+
+      expect(
+        screen.queryByTestId("chat-message-persona-u1"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("chat-message-persona-a1")).toBeInTheDocument();
+    });
+
+    it("shows the fallback persona name 'Tandem' on assistant messages when the session has no personaId", () => {
+      seedTabs(["sess-1"], "sess-1");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-1",
+            title: "Existing chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+          },
+        ],
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-1": [
+            {
+              id: "a1",
+              role: "assistant",
+              created: 1,
+              content: [{ type: "text", text: "hello back" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+      });
+
+      render(<AppShell />);
+
+      expect(screen.getByTestId("chat-message-persona-a1")).toHaveTextContent(
+        "Tandem",
+      );
     });
 
     it("shows a typing indicator while the assistant is generating", () => {

--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 
 vi.mock("@/shared/api/acpConnection", () => ({
   getClient: vi.fn(() => new Promise(() => {})),
+  setNotificationHandler: vi.fn(),
 }));
 
 const { mockAcpCreateSession, mockAcpSendMessage, mockResolvePath } =

--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -591,6 +591,48 @@ describe("AppShell", () => {
         "hello world",
       );
     });
+
+    it("includes attached image in the ACP prompt payload as options.images", async () => {
+      const user = userEvent.setup();
+      const draftId = `${DRAFT_TAB_PREFIX}img`;
+      seedTabs([draftId], draftId);
+
+      mockAcpCreateSession.mockResolvedValue({
+        sessionId: "real-session-img",
+      });
+
+      render(<AppShell />);
+
+      const fileInput = screen.getByTestId(
+        "chat-composer-attach-input",
+      ) as HTMLInputElement;
+      const file = new File(["fake-png-bytes"], "diagram.png", {
+        type: "image/png",
+      });
+      await user.upload(fileInput, file);
+      await screen.findByTestId("chat-composer-attachment-chip");
+
+      const input = screen.getByTestId("chat-composer-input");
+      await user.type(input, "look at this");
+      await user.keyboard("{Enter}");
+
+      await waitFor(
+        () => {
+          expect(mockAcpSendMessage).toHaveBeenCalled();
+        },
+        { timeout: 3000 },
+      );
+
+      const [sessionId, text, options] = mockAcpSendMessage.mock.calls[0];
+      expect(sessionId).toBe("real-session-img");
+      expect(text).toBe("look at this");
+      expect(options).toBeDefined();
+      expect(options.images).toHaveLength(1);
+      const [data, mimeType] = options.images[0];
+      expect(typeof data).toBe("string");
+      expect(data.length).toBeGreaterThan(0);
+      expect(mimeType).toBe("image/png");
+    });
   });
 
   it("clicking a tab close button removes the tab but keeps the session in history", async () => {

--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -632,6 +632,59 @@ describe("AppShell", () => {
       expect(screen.getByTestId("chat-typing-indicator")).toBeInTheDocument();
     });
 
+    it("composer footer reflects the active session's tokenState from chatStore", () => {
+      seedTabs(["sess-1"], "sess-1");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-1",
+            title: "Existing chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+          },
+        ],
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-1": [
+            {
+              id: "u1",
+              role: "user",
+              created: 1,
+              content: [{ type: "text", text: "hi" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+        sessionStateById: {
+          "sess-1": {
+            chatState: "idle",
+            tokenState: {
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+              accumulatedInput: 0,
+              accumulatedOutput: 0,
+              accumulatedTotal: 8420,
+              contextLimit: 200000,
+            },
+            hasUsageSnapshot: true,
+            streamingMessageId: null,
+            pendingAssistantProviderId: null,
+            error: null,
+            hasUnread: false,
+          },
+        },
+      });
+
+      render(<AppShell />);
+
+      expect(screen.getByTestId("chat-composer-token-counter")).toHaveTextContent(
+        "8.4k / 200k",
+      );
+    });
+
     it("hides the typing indicator when chatState is idle", () => {
       seedTabs(["sess-1"], "sess-1");
       useChatSessionStore.setState({

--- a/ui/tandem/src/app/hooks/__tests__/useAppStartup.test.ts
+++ b/ui/tandem/src/app/hooks/__tests__/useAppStartup.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { SessionNotification } from "@agentclientprotocol/sdk";
+import type { ProviderInventoryEntryDto } from "@aaif/goose-sdk";
 
-const { mockSetNotificationHandler, mockGetClient } = vi.hoisted(() => ({
-  mockSetNotificationHandler: vi.fn(),
-  mockGetClient: vi.fn(),
-}));
+const { mockSetNotificationHandler, mockGetClient, mockGetProviderInventory } =
+  vi.hoisted(() => ({
+    mockSetNotificationHandler: vi.fn(),
+    mockGetClient: vi.fn(),
+    mockGetProviderInventory: vi.fn(),
+  }));
 
 vi.mock("@/shared/api/acpConnection", () => ({
   setNotificationHandler: mockSetNotificationHandler,
@@ -20,20 +23,51 @@ vi.mock("@/shared/api/acp", async (importActual) => {
   };
 });
 
+vi.mock("@/features/providers/api/inventory", () => ({
+  getProviderInventory: mockGetProviderInventory,
+}));
+
 import { useAppStartup } from "@/app/hooks/useAppStartup";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import { useProviderInventoryStore } from "@/features/providers/stores/providerInventoryStore";
 import {
   registerSession,
   unregisterSession,
 } from "@/shared/api/acpSessionTracker";
 import type { AcpNotificationHandler } from "@/shared/api/acpConnection";
 
+function makeEntry(
+  providerId: string,
+  configured: boolean,
+): ProviderInventoryEntryDto {
+  return {
+    providerId,
+    providerName: providerId,
+    description: "",
+    defaultModel: "default",
+    configured,
+    providerType: "Builtin",
+    configKeys: [],
+    setupSteps: [],
+    supportsRefresh: false,
+    refreshing: false,
+    models: [],
+    stale: false,
+  };
+}
+
 describe("useAppStartup ACP notification wire-up (slice 7b)", () => {
   beforeEach(() => {
     mockSetNotificationHandler.mockReset();
     mockGetClient.mockReset();
     mockGetClient.mockResolvedValue({});
+    mockGetProviderInventory.mockReset();
+    mockGetProviderInventory.mockResolvedValue([]);
+    useProviderInventoryStore.setState({
+      entries: new Map<string, ProviderInventoryEntryDto>(),
+      loading: false,
+    });
     useChatStore.setState({
       messagesBySession: {},
       sessionStateById: {},
@@ -97,5 +131,38 @@ describe("useAppStartup ACP notification wire-up (slice 7b)", () => {
     if (textBlock?.type === "text") {
       expect(textBlock.text).toBe("hello from agent");
     }
+  });
+});
+
+describe("useAppStartup provider inventory load (slice 11)", () => {
+  beforeEach(() => {
+    mockSetNotificationHandler.mockReset();
+    mockGetClient.mockReset();
+    mockGetClient.mockResolvedValue({});
+    mockGetProviderInventory.mockReset();
+    useProviderInventoryStore.setState({
+      entries: new Map<string, ProviderInventoryEntryDto>(),
+      loading: false,
+    });
+  });
+
+  it("populates providerInventoryStore from getProviderInventory() on mount", async () => {
+    mockGetProviderInventory.mockResolvedValue([
+      makeEntry("openai", true),
+      makeEntry("anthropic", false),
+    ]);
+
+    renderHook(() => useAppStartup());
+
+    await waitFor(() => {
+      expect(mockGetProviderInventory).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(useProviderInventoryStore.getState().entries.size).toBe(2);
+    });
+
+    const entries = useProviderInventoryStore.getState().entries;
+    expect(entries.get("openai")?.configured).toBe(true);
+    expect(entries.get("anthropic")?.configured).toBe(false);
   });
 });

--- a/ui/tandem/src/app/hooks/__tests__/useAppStartup.test.ts
+++ b/ui/tandem/src/app/hooks/__tests__/useAppStartup.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+
+const { mockSetNotificationHandler, mockGetClient } = vi.hoisted(() => ({
+  mockSetNotificationHandler: vi.fn(),
+  mockGetClient: vi.fn(),
+}));
+
+vi.mock("@/shared/api/acpConnection", () => ({
+  setNotificationHandler: mockSetNotificationHandler,
+  getClient: mockGetClient,
+}));
+
+vi.mock("@/shared/api/acp", async (importActual) => {
+  const actual = await importActual<typeof import("@/shared/api/acp")>();
+  return {
+    ...actual,
+    acpListSessions: vi.fn(async () => []),
+  };
+});
+
+import { useAppStartup } from "@/app/hooks/useAppStartup";
+import { useChatStore } from "@/features/chat/stores/chatStore";
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import {
+  registerSession,
+  unregisterSession,
+} from "@/shared/api/acpSessionTracker";
+import type { AcpNotificationHandler } from "@/shared/api/acpConnection";
+
+describe("useAppStartup ACP notification wire-up (slice 7b)", () => {
+  beforeEach(() => {
+    mockSetNotificationHandler.mockReset();
+    mockGetClient.mockReset();
+    mockGetClient.mockResolvedValue({});
+    useChatStore.setState({
+      messagesBySession: {},
+      sessionStateById: {},
+      queuedMessageBySession: {},
+      draftsBySession: {},
+      activeSessionId: null,
+      isConnected: false,
+      loadingSessionIds: new Set<string>(),
+      scrollTargetMessageBySession: {},
+    });
+    useChatSessionStore.setState({
+      sessions: [],
+      activeSessionId: null,
+      hasHydratedSessions: false,
+    });
+  });
+
+  afterEach(() => {
+    unregisterSession("local-session-7b", "goose-session-7b");
+  });
+
+  it("routes a SessionNotification to chatStore.messagesBySession", async () => {
+    renderHook(() => useAppStartup());
+
+    await waitFor(() => {
+      expect(mockSetNotificationHandler).toHaveBeenCalledTimes(1);
+    });
+
+    const handler = mockSetNotificationHandler.mock.calls[0]?.[0] as
+      | AcpNotificationHandler
+      | undefined;
+    expect(handler).toBeDefined();
+    expect(typeof handler?.handleSessionNotification).toBe("function");
+
+    registerSession(
+      "local-session-7b",
+      "goose-session-7b",
+      "goose",
+      "/tmp/test",
+    );
+
+    const notification: SessionNotification = {
+      sessionId: "goose-session-7b",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "assistant-msg-1",
+        content: { type: "text", text: "hello from agent" },
+      },
+    } as SessionNotification;
+
+    await handler!.handleSessionNotification(notification);
+
+    const messages =
+      useChatStore.getState().messagesBySession["local-session-7b"];
+    expect(messages).toBeDefined();
+    expect(messages).toHaveLength(1);
+    expect(messages?.[0]?.id).toBe("assistant-msg-1");
+    expect(messages?.[0]?.role).toBe("assistant");
+    const textBlock = messages?.[0]?.content[0];
+    expect(textBlock?.type).toBe("text");
+    if (textBlock?.type === "text") {
+      expect(textBlock.text).toBe("hello from agent");
+    }
+  });
+});

--- a/ui/tandem/src/app/hooks/useAppStartup.ts
+++ b/ui/tandem/src/app/hooks/useAppStartup.ts
@@ -1,12 +1,27 @@
 import { useEffect } from "react";
 
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import {
+  getClient,
+  setNotificationHandler,
+} from "@/shared/api/acpConnection";
+import notificationHandler from "@/shared/api/acpNotificationHandler";
 
-// Phase 2 startup: hydrate the session list so the LeftPane history populates
-// from goose serve. Phase 3 will expand this to load provider inventory,
-// personas, etc. — see ui/goose2/src/app/hooks/useAppStartup.ts for the shape.
+// Phase 3a startup: register the chat notification handler so ACP
+// session_update events flow into chatStore, then prime the ACP client and
+// hydrate the session list. Phase 3b+ will expand this with provider
+// inventory, personas, etc. — see ui/goose2/src/app/hooks/useAppStartup.ts
+// for the fully-loaded shape.
 export function useAppStartup(): void {
   useEffect(() => {
-    void useChatSessionStore.getState().loadSessions();
+    void (async () => {
+      try {
+        setNotificationHandler(notificationHandler);
+        await getClient();
+      } catch (err) {
+        console.error("Failed to initialize ACP connection:", err);
+      }
+      void useChatSessionStore.getState().loadSessions();
+    })();
   }, []);
 }

--- a/ui/tandem/src/app/hooks/useAppStartup.ts
+++ b/ui/tandem/src/app/hooks/useAppStartup.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import { useProviderInventoryStore } from "@/features/providers/stores/providerInventoryStore";
 import {
   getClient,
   setNotificationHandler,
@@ -8,10 +9,10 @@ import {
 import notificationHandler from "@/shared/api/acpNotificationHandler";
 
 // Phase 3a startup: register the chat notification handler so ACP
-// session_update events flow into chatStore, then prime the ACP client and
-// hydrate the session list. Phase 3b+ will expand this with provider
-// inventory, personas, etc. — see ui/goose2/src/app/hooks/useAppStartup.ts
-// for the fully-loaded shape.
+// session_update events flow into chatStore, prime the ACP client, load the
+// provider inventory (gates the no-providers banner), then hydrate the
+// session list. Phase 3b+ will expand this with personas, etc. — see
+// ui/goose2/src/app/hooks/useAppStartup.ts for the fully-loaded shape.
 export function useAppStartup(): void {
   useEffect(() => {
     void (async () => {
@@ -21,6 +22,21 @@ export function useAppStartup(): void {
       } catch (err) {
         console.error("Failed to initialize ACP connection:", err);
       }
+      void (async () => {
+        const inventoryStore = useProviderInventoryStore.getState();
+        inventoryStore.setLoading(true);
+        try {
+          const { getProviderInventory } = await import(
+            "@/features/providers/api/inventory"
+          );
+          const entries = await getProviderInventory();
+          inventoryStore.setEntries(entries);
+        } catch (err) {
+          console.error("Failed to load provider inventory on startup:", err);
+        } finally {
+          inventoryStore.setLoading(false);
+        }
+      })();
       void useChatSessionStore.getState().loadSessions();
     })();
   }, []);

--- a/ui/tandem/src/features/chat/hooks/__tests__/useChat.test.ts
+++ b/ui/tandem/src/features/chat/hooks/__tests__/useChat.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const { mockAcpSendMessage, mockResolvePath } = vi.hoisted(() => ({
+  mockAcpSendMessage: vi.fn(),
+  mockResolvePath: vi.fn(),
+}));
+
+vi.mock("@/shared/api/acp", async (importActual) => {
+  const actual = await importActual<typeof import("@/shared/api/acp")>();
+  return {
+    ...actual,
+    acpSendMessage: mockAcpSendMessage,
+  };
+});
+
+vi.mock("@/shared/api/pathResolver", () => ({
+  resolvePath: mockResolvePath,
+}));
+
+import { useChat } from "@/features/chat/hooks/useChat";
+import { useChatStore } from "@/features/chat/stores/chatStore";
+
+describe("useChat (slice 8.5)", () => {
+  beforeEach(() => {
+    mockAcpSendMessage.mockReset();
+    mockAcpSendMessage.mockResolvedValue(undefined);
+    mockResolvePath.mockReset();
+    mockResolvePath.mockResolvedValue({ path: "/home/test/.goose/artifacts" });
+    useChatStore.setState({
+      messagesBySession: {},
+      sessionStateById: {},
+      queuedMessageBySession: {},
+      draftsBySession: {},
+      activeSessionId: null,
+      isConnected: false,
+      loadingSessionIds: new Set<string>(),
+      scrollTargetMessageBySession: {},
+    });
+  });
+
+  it("forwards image attachments to acpSendMessage as options.images", async () => {
+    const sessionId = "real-session-abc";
+    const { result } = renderHook(() => useChat(sessionId));
+
+    await act(async () => {
+      await result.current.send("look at this", [
+        {
+          name: "diagram.png",
+          mimeType: "image/png",
+          data: "BASE64DATA",
+        },
+      ]);
+    });
+
+    expect(mockAcpSendMessage).toHaveBeenCalledTimes(1);
+    const [callSessionId, callText, callOptions] =
+      mockAcpSendMessage.mock.calls[0];
+    expect(callSessionId).toBe(sessionId);
+    expect(callText).toBe("look at this");
+    expect(callOptions).toMatchObject({
+      images: [["BASE64DATA", "image/png"]],
+    });
+  });
+
+  it("does not pass options.images when no attachments are provided", async () => {
+    const sessionId = "real-session-def";
+    const { result } = renderHook(() => useChat(sessionId));
+
+    await act(async () => {
+      await result.current.send("hi");
+    });
+
+    expect(mockAcpSendMessage).toHaveBeenCalledTimes(1);
+    const call = mockAcpSendMessage.mock.calls[0];
+    expect(call).toEqual([sessionId, "hi"]);
+  });
+});

--- a/ui/tandem/src/features/chat/hooks/useChat.ts
+++ b/ui/tandem/src/features/chat/hooks/useChat.ts
@@ -9,6 +9,7 @@ import {
   useTabsStore,
 } from "@/features/tabs/stores/tabsStore";
 import { createUserMessage } from "@/shared/types/messages";
+import type { ComposerAttachment } from "@/features/chat/ui/Composer";
 
 const isDraftId = (id: string) => id.startsWith(DRAFT_TAB_PREFIX);
 
@@ -18,7 +19,7 @@ async function defaultWorkingDir(): Promise<string> {
 }
 
 export interface UseChatResult {
-  send: (text: string) => Promise<void>;
+  send: (text: string, attachments?: ComposerAttachment[]) => Promise<void>;
   hasMessages: boolean;
 }
 
@@ -28,7 +29,7 @@ export function useChat(tabId: string | null): UseChatResult {
   );
 
   const send = useCallback(
-    async (text: string) => {
+    async (text: string, attachments?: ComposerAttachment[]) => {
       if (!tabId) return;
 
       let sessionId = tabId;
@@ -42,7 +43,15 @@ export function useChat(tabId: string | null): UseChatResult {
       }
 
       useChatStore.getState().addMessage(sessionId, createUserMessage(text));
-      await acpSendMessage(sessionId, text);
+      if (attachments && attachments.length > 0) {
+        const images: [string, string][] = attachments.map((a) => [
+          a.data,
+          a.mimeType,
+        ]);
+        await acpSendMessage(sessionId, text, { images });
+      } else {
+        await acpSendMessage(sessionId, text);
+      }
     },
     [tabId],
   );

--- a/ui/tandem/src/features/chat/ui/ChatPane.tsx
+++ b/ui/tandem/src/features/chat/ui/ChatPane.tsx
@@ -1,4 +1,5 @@
 import { useChat } from "@/features/chat/hooks/useChat";
+import { useChatStore } from "@/features/chat/stores/chatStore";
 import { Composer } from "@/features/chat/ui/Composer";
 import { EmptyState } from "@/features/chat/ui/EmptyState";
 import { Timeline } from "@/features/chat/ui/Timeline";
@@ -7,6 +8,9 @@ import { useTabsStore } from "@/features/tabs/stores/tabsStore";
 export const ChatPane = () => {
   const activeTabId = useTabsStore((s) => s.activeId);
   const { send, hasMessages } = useChat(activeTabId);
+  const tokenState = useChatStore((s) =>
+    activeTabId ? s.sessionStateById[activeTabId]?.tokenState : undefined,
+  );
 
   if (!activeTabId || !hasMessages) {
     return <EmptyState onSend={send} />;
@@ -27,7 +31,11 @@ export const ChatPane = () => {
           justifyContent: "center",
         }}
       >
-        <Composer onSend={send} />
+        <Composer
+          onSend={send}
+          tokenUsed={tokenState?.accumulatedTotal ?? 0}
+          tokenLimit={tokenState?.contextLimit ?? 0}
+        />
       </div>
     </div>
   );

--- a/ui/tandem/src/features/chat/ui/ChatPane.tsx
+++ b/ui/tandem/src/features/chat/ui/ChatPane.tsx
@@ -2,7 +2,9 @@ import { useChat } from "@/features/chat/hooks/useChat";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import { Composer } from "@/features/chat/ui/Composer";
 import { EmptyState } from "@/features/chat/ui/EmptyState";
+import { ProvidersBanner } from "@/features/chat/ui/ProvidersBanner";
 import { Timeline } from "@/features/chat/ui/Timeline";
+import { useProviderInventoryStore } from "@/features/providers/stores/providerInventoryStore";
 import { useTabsStore } from "@/features/tabs/stores/tabsStore";
 
 export const ChatPane = () => {
@@ -11,32 +13,57 @@ export const ChatPane = () => {
   const tokenState = useChatStore((s) =>
     activeTabId ? s.sessionStateById[activeTabId]?.tokenState : undefined,
   );
-
-  if (!activeTabId || !hasMessages) {
-    return <EmptyState onSend={send} />;
-  }
+  const hasConfiguredProvider = useProviderInventoryStore((s) => {
+    for (const entry of s.entries.values()) {
+      if (entry.configured) return true;
+    }
+    return false;
+  });
 
   return (
     <div
-      data-testid="chat-active"
-      style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}
+      style={{
+        flex: 1,
+        display: "flex",
+        flexDirection: "column",
+        minHeight: 0,
+      }}
     >
-      <Timeline sessionId={activeTabId} />
-      <div
-        style={{
-          padding: "8px 16px 16px",
-          borderTop: "1px solid var(--color-border-subtle)",
-          background: "var(--color-canvas)",
-          display: "flex",
-          justifyContent: "center",
-        }}
-      >
-        <Composer
+      {!hasConfiguredProvider && <ProvidersBanner />}
+      {!activeTabId || !hasMessages ? (
+        <EmptyState
           onSend={send}
-          tokenUsed={tokenState?.accumulatedTotal ?? 0}
-          tokenLimit={tokenState?.contextLimit ?? 0}
+          composerDisabled={!hasConfiguredProvider}
         />
-      </div>
+      ) : (
+        <div
+          data-testid="chat-active"
+          style={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            minHeight: 0,
+          }}
+        >
+          <Timeline sessionId={activeTabId} />
+          <div
+            style={{
+              padding: "8px 16px 16px",
+              borderTop: "1px solid var(--color-border-subtle)",
+              background: "var(--color-canvas)",
+              display: "flex",
+              justifyContent: "center",
+            }}
+          >
+            <Composer
+              onSend={send}
+              tokenUsed={tokenState?.accumulatedTotal ?? 0}
+              tokenLimit={tokenState?.contextLimit ?? 0}
+              disabled={!hasConfiguredProvider}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/ui/tandem/src/features/chat/ui/Composer.tsx
+++ b/ui/tandem/src/features/chat/ui/Composer.tsx
@@ -1,8 +1,37 @@
-import { useState, type KeyboardEvent } from "react";
+import {
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from "react";
+import { FileText, Paperclip, X } from "lucide-react";
+
+export interface ComposerAttachment {
+  name: string;
+  mimeType: string;
+  data: string;
+}
 
 export interface ComposerProps {
   placeholder?: string;
-  onSend?: (text: string) => void;
+  onSend?: (text: string, attachments: ComposerAttachment[]) => void;
+}
+
+function readAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== "string") {
+        reject(new Error("FileReader result was not a string"));
+        return;
+      }
+      const comma = result.indexOf(",");
+      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
 }
 
 export const Composer = ({
@@ -10,14 +39,31 @@ export const Composer = ({
   onSend,
 }: ComposerProps) => {
   const [value, setValue] = useState("");
+  const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    e.target.value = "";
+    if (files.length === 0) return;
+    const next = await Promise.all(
+      files.map(async (file) => ({
+        name: file.name,
+        mimeType: file.type || "application/octet-stream",
+        data: await readAsBase64(file),
+      })),
+    );
+    setAttachments((prev) => [...prev, ...next]);
+  };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       const trimmed = value.trim();
       if (!trimmed) return;
-      onSend?.(trimmed);
+      onSend?.(trimmed, attachments);
       setValue("");
+      setAttachments([]);
     }
   };
 
@@ -36,6 +82,59 @@ export const Composer = ({
         gap: 8,
       }}
     >
+      {attachments.length > 0 && (
+        <div
+          data-testid="chat-composer-attachments"
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 6,
+          }}
+        >
+          {attachments.map((a, i) => (
+            <div
+              key={`${a.name}-${i}`}
+              data-testid="chat-composer-attachment-chip"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "4px 8px",
+                background: "var(--color-raised)",
+                border: "1px solid var(--color-border-subtle)",
+                borderRadius: 999,
+                color: "var(--color-text-muted)",
+                fontSize: 12,
+              }}
+            >
+              <FileText size={11} />
+              <span>{a.name}</span>
+              <button
+                type="button"
+                data-testid="chat-composer-attachment-remove"
+                aria-label={`Remove ${a.name}`}
+                onClick={() =>
+                  setAttachments((prev) => prev.filter((_, j) => j !== i))
+                }
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: 16,
+                  height: 16,
+                  background: "transparent",
+                  border: "none",
+                  color: "var(--color-text-muted)",
+                  cursor: "pointer",
+                  padding: 0,
+                }}
+              >
+                <X size={10} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
       <textarea
         data-testid="chat-composer-input"
         placeholder={placeholder}
@@ -67,7 +166,36 @@ export const Composer = ({
           fontSize: 12,
         }}
       >
-        {/* Stub footer — real chips land in Phase 3b */}
+        <button
+          type="button"
+          data-testid="chat-composer-attach"
+          aria-label="Attach file"
+          title="Attach file"
+          onClick={() => fileInputRef.current?.click()}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 24,
+            height: 24,
+            background: "transparent",
+            border: "none",
+            color: "var(--color-text-muted)",
+            cursor: "pointer",
+            padding: 0,
+          }}
+        >
+          <Paperclip size={13} />
+        </button>
+        <input
+          ref={fileInputRef}
+          data-testid="chat-composer-attach-input"
+          type="file"
+          accept="image/*"
+          multiple
+          onChange={handleFileChange}
+          style={{ display: "none" }}
+        />
       </div>
     </div>
   );

--- a/ui/tandem/src/features/chat/ui/Composer.tsx
+++ b/ui/tandem/src/features/chat/ui/Composer.tsx
@@ -4,7 +4,14 @@ import {
   type ChangeEvent,
   type KeyboardEvent,
 } from "react";
-import { FileText, Paperclip, X } from "lucide-react";
+import {
+  Brain,
+  ChevronDown,
+  FileText,
+  Paperclip,
+  Plug,
+  X,
+} from "lucide-react";
 
 export interface ComposerAttachment {
   name: string;
@@ -15,6 +22,18 @@ export interface ComposerAttachment {
 export interface ComposerProps {
   placeholder?: string;
   onSend?: (text: string, attachments: ComposerAttachment[]) => void;
+  contextFolder?: string;
+  mcpCount?: number;
+  tokenUsed?: number;
+  tokenLimit?: number;
+}
+
+function formatTokenCount(used: number, limit: number): string {
+  if (limit <= 0) return String(used);
+  const usedK = used / 1000;
+  const usedStr = usedK.toFixed(used >= 10000 ? 0 : 1).replace(/\.0$/, "");
+  const limitStr = (limit / 1000).toFixed(0);
+  return `${usedStr}k / ${limitStr}k`;
 }
 
 function readAsBase64(file: File): Promise<string> {
@@ -34,10 +53,37 @@ function readAsBase64(file: File): Promise<string> {
   });
 }
 
+const chipStyle = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 6,
+  height: 26,
+  padding: "0 8px",
+  borderRadius: 6,
+  background: "transparent",
+  border: "none",
+  color: "var(--color-text-muted)",
+  fontSize: 12,
+  fontFamily: "var(--font-ui)",
+  whiteSpace: "nowrap" as const,
+};
+
 export const Composer = ({
   placeholder = "Ask anything, or paste a file…",
   onSend,
+  contextFolder = "Default",
+  mcpCount = 0,
+  tokenUsed = 0,
+  tokenLimit = 0,
 }: ComposerProps) => {
+  const tokenLabel = formatTokenCount(tokenUsed, tokenLimit);
+  const tokenPct = tokenLimit > 0 ? Math.min(100, (tokenUsed / tokenLimit) * 100) : 0;
+  const tokenFillColor =
+    tokenPct > 80
+      ? "var(--color-danger)"
+      : tokenPct > 60
+        ? "var(--color-warning)"
+        : "var(--color-success)";
   const [value, setValue] = useState("");
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -161,11 +207,16 @@ export const Composer = ({
           height: 28,
           display: "flex",
           alignItems: "center",
-          gap: 8,
+          gap: 2,
           color: "var(--color-text-muted)",
           fontSize: 12,
         }}
       >
+        <div data-testid="chat-composer-context-folder" style={chipStyle}>
+          <Brain size={13} />
+          <span>{contextFolder}</span>
+          <ChevronDown size={11} style={{ opacity: 0.6 }} />
+        </div>
         <button
           type="button"
           data-testid="chat-composer-attach"
@@ -196,6 +247,65 @@ export const Composer = ({
           onChange={handleFileChange}
           style={{ display: "none" }}
         />
+        <div style={{ flex: 1 }} />
+        <div data-testid="chat-composer-token-counter" style={chipStyle}>
+          {tokenLimit > 0 && (
+            <div
+              style={{
+                width: 40,
+                height: 4,
+                background: "var(--color-border)",
+                borderRadius: 999,
+                overflow: "hidden",
+              }}
+            >
+              <div
+                style={{
+                  width: `${tokenPct}%`,
+                  height: "100%",
+                  background: tokenFillColor,
+                }}
+              />
+            </div>
+          )}
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              color: "var(--color-text-faint)",
+              fontSize: 11,
+            }}
+          >
+            {tokenLabel}
+          </span>
+        </div>
+        <div
+          style={{
+            width: 1,
+            height: 16,
+            background: "var(--color-border)",
+            margin: "0 4px",
+          }}
+        />
+        <div data-testid="chat-composer-mcp-count" style={chipStyle}>
+          <Plug size={13} />
+          <span>MCP</span>
+          <span
+            style={{
+              background: "var(--color-accent-dim)",
+              color: "var(--color-accent)",
+              borderRadius: 999,
+              padding: "1px 6px",
+              fontSize: 10,
+              fontFamily: "var(--font-mono)",
+              fontWeight: 600,
+              minWidth: 16,
+              textAlign: "center",
+            }}
+          >
+            {mcpCount}
+          </span>
+          <ChevronDown size={11} style={{ opacity: 0.6 }} />
+        </div>
       </div>
     </div>
   );

--- a/ui/tandem/src/features/chat/ui/Composer.tsx
+++ b/ui/tandem/src/features/chat/ui/Composer.tsx
@@ -26,6 +26,7 @@ export interface ComposerProps {
   mcpCount?: number;
   tokenUsed?: number;
   tokenLimit?: number;
+  disabled?: boolean;
 }
 
 function formatTokenCount(used: number, limit: number): string {
@@ -75,6 +76,7 @@ export const Composer = ({
   mcpCount = 0,
   tokenUsed = 0,
   tokenLimit = 0,
+  disabled = false,
 }: ComposerProps) => {
   const tokenLabel = formatTokenCount(tokenUsed, tokenLimit);
   const tokenPct = tokenLimit > 0 ? Math.min(100, (tokenUsed / tokenLimit) * 100) : 0;
@@ -188,6 +190,7 @@ export const Composer = ({
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={handleKeyDown}
+        disabled={disabled}
         style={{
           width: "100%",
           minHeight: 44,
@@ -223,6 +226,7 @@ export const Composer = ({
           aria-label="Attach file"
           title="Attach file"
           onClick={() => fileInputRef.current?.click()}
+          disabled={disabled}
           style={{
             display: "inline-flex",
             alignItems: "center",
@@ -232,7 +236,8 @@ export const Composer = ({
             background: "transparent",
             border: "none",
             color: "var(--color-text-muted)",
-            cursor: "pointer",
+            cursor: disabled ? "not-allowed" : "pointer",
+            opacity: disabled ? 0.5 : 1,
             padding: 0,
           }}
         >

--- a/ui/tandem/src/features/chat/ui/EmptyState.tsx
+++ b/ui/tandem/src/features/chat/ui/EmptyState.tsx
@@ -1,10 +1,13 @@
 import { getTimeOfDay } from "@/features/chat/lib/timeOfDay";
 import { DEFAULT_USER_NAME } from "@/features/chat/lib/userIdentity";
-import { Composer } from "@/features/chat/ui/Composer";
+import {
+  Composer,
+  type ComposerAttachment,
+} from "@/features/chat/ui/Composer";
 
 export interface EmptyStateProps {
   name?: string;
-  onSend?: (text: string) => void;
+  onSend?: (text: string, attachments: ComposerAttachment[]) => void;
 }
 
 export const EmptyState = ({

--- a/ui/tandem/src/features/chat/ui/EmptyState.tsx
+++ b/ui/tandem/src/features/chat/ui/EmptyState.tsx
@@ -8,11 +8,13 @@ import {
 export interface EmptyStateProps {
   name?: string;
   onSend?: (text: string, attachments: ComposerAttachment[]) => void;
+  composerDisabled?: boolean;
 }
 
 export const EmptyState = ({
   name = DEFAULT_USER_NAME,
   onSend,
+  composerDisabled = false,
 }: EmptyStateProps) => {
   const tod = getTimeOfDay();
   return (
@@ -41,7 +43,7 @@ export const EmptyState = ({
         <br />
         <em>What are we working on?</em>
       </div>
-      <Composer onSend={onSend} />
+      <Composer onSend={onSend} disabled={composerDisabled} />
     </div>
   );
 };

--- a/ui/tandem/src/features/chat/ui/ProvidersBanner.tsx
+++ b/ui/tandem/src/features/chat/ui/ProvidersBanner.tsx
@@ -1,0 +1,31 @@
+import { AlertTriangle } from "lucide-react";
+
+export const ProvidersBanner = () => {
+  return (
+    <div
+      data-testid="chat-providers-banner"
+      role="alert"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "8px 16px",
+        background: "var(--color-warning-dim)",
+        borderBottom: "1px solid var(--color-warning)",
+        color: "var(--color-text)",
+        fontFamily: "var(--font-ui)",
+        fontSize: 13,
+      }}
+    >
+      <AlertTriangle
+        size={16}
+        color="var(--color-warning)"
+        aria-hidden="true"
+      />
+      <span>
+        No providers configured. Open goose2 to set up an API key, then
+        restart Tandem.
+      </span>
+    </div>
+  );
+};

--- a/ui/tandem/src/features/chat/ui/Timeline.tsx
+++ b/ui/tandem/src/features/chat/ui/Timeline.tsx
@@ -1,9 +1,23 @@
 import { Sparkles } from "lucide-react";
 
 import { useChatStore } from "@/features/chat/stores/chatStore";
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { getUserInitials } from "@/features/chat/lib/userIdentity";
 import { getTextContent, type Message } from "@/shared/types/messages";
 import type { ChatState } from "@/shared/types/chat";
+
+const FALLBACK_PERSONA_NAME = "Tandem";
+
+function usePersonaNameForSession(sessionId: string): string {
+  const personaId = useChatSessionStore(
+    (s) => s.sessions.find((x) => x.id === sessionId)?.personaId,
+  );
+  const personaName = useAgentStore((s) =>
+    personaId ? s.personas.find((p) => p.id === personaId)?.displayName : undefined,
+  );
+  return personaName ?? FALLBACK_PERSONA_NAME;
+}
 
 export interface TimelineProps {
   sessionId: string;
@@ -23,6 +37,7 @@ export const Timeline = ({ sessionId }: TimelineProps) => {
   const chatState = useChatStore(
     (s) => s.sessionStateById[sessionId]?.chatState ?? "idle",
   );
+  const personaName = usePersonaNameForSession(sessionId);
   const showTypingIndicator = ASSISTANT_BUSY_STATES.has(chatState);
 
   return (
@@ -38,7 +53,7 @@ export const Timeline = ({ sessionId }: TimelineProps) => {
       }}
     >
       {messages.map((m) => (
-        <MessageRow key={m.id} message={m} />
+        <MessageRow key={m.id} message={m} personaName={personaName} />
       ))}
       {showTypingIndicator && <TypingIndicator />}
     </div>
@@ -124,7 +139,14 @@ const Avatar = ({ message }: { message: Message }) => {
   );
 };
 
-const MessageRow = ({ message }: { message: Message }) => {
+const MessageRow = ({
+  message,
+  personaName,
+}: {
+  message: Message;
+  personaName: string;
+}) => {
+  const isAssistant = message.role === "assistant";
   return (
     <div
       data-testid={`chat-message-${message.role}`}
@@ -138,14 +160,36 @@ const MessageRow = ({ message }: { message: Message }) => {
       <Avatar message={message} />
       <div
         style={{
-          fontFamily: "var(--font-reading)",
-          color: "var(--color-text)",
-          whiteSpace: "pre-wrap",
-          lineHeight: 1.55,
-          paddingTop: 4,
+          display: "flex",
+          flexDirection: "column",
+          minWidth: 0,
         }}
       >
-        {getTextContent(message)}
+        {isAssistant && (
+          <div
+            data-testid={`chat-message-persona-${message.id}`}
+            style={{
+              fontFamily: "var(--font-ui)",
+              fontSize: 12,
+              color: "var(--color-text)",
+              fontWeight: 500,
+              marginBottom: 2,
+            }}
+          >
+            {personaName}
+          </div>
+        )}
+        <div
+          style={{
+            fontFamily: "var(--font-reading)",
+            color: "var(--color-text)",
+            whiteSpace: "pre-wrap",
+            lineHeight: 1.55,
+            paddingTop: isAssistant ? 0 : 4,
+          }}
+        >
+          {getTextContent(message)}
+        </div>
       </div>
     </div>
   );

--- a/ui/tandem/src/features/chat/ui/__tests__/Composer.test.tsx
+++ b/ui/tandem/src/features/chat/ui/__tests__/Composer.test.tsx
@@ -158,6 +158,62 @@ describe("Composer", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders a read-only context-folder chip in the footer (default 'Default')", () => {
+    render(<Composer />);
+    const chip = screen.getByTestId("chat-composer-context-folder");
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveTextContent("Default");
+  });
+
+  it("renders the contextFolder prop value in the chip", () => {
+    render(<Composer contextFolder="my-project" />);
+    expect(screen.getByTestId("chat-composer-context-folder")).toHaveTextContent(
+      "my-project",
+    );
+  });
+
+  it("renders a read-only MCP count chip in the footer (default 0)", () => {
+    render(<Composer />);
+    const chip = screen.getByTestId("chat-composer-mcp-count");
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveTextContent("MCP");
+    expect(chip).toHaveTextContent("0");
+  });
+
+  it("renders the mcpCount prop value in the badge", () => {
+    render(<Composer mcpCount={3} />);
+    expect(screen.getByTestId("chat-composer-mcp-count")).toHaveTextContent("3");
+  });
+
+  it("renders a token-counter chip showing '0' when tokenLimit is unknown", () => {
+    render(<Composer />);
+    const chip = screen.getByTestId("chat-composer-token-counter");
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveTextContent("0");
+    expect(chip).not.toHaveTextContent("/");
+  });
+
+  it("formats the token counter as 'X.Xk / Yk' when limit > 0 (sub-10k uses one decimal)", () => {
+    render(<Composer tokenUsed={8420} tokenLimit={200000} />);
+    expect(screen.getByTestId("chat-composer-token-counter")).toHaveTextContent(
+      "8.4k / 200k",
+    );
+  });
+
+  it("drops the trailing '.0' from the used side (e.g. 1000 -> '1k')", () => {
+    render(<Composer tokenUsed={1000} tokenLimit={200000} />);
+    expect(screen.getByTestId("chat-composer-token-counter")).toHaveTextContent(
+      "1k / 200k",
+    );
+  });
+
+  it("renders the used side without a decimal once at or above 10000", () => {
+    render(<Composer tokenUsed={12345} tokenLimit={200000} />);
+    expect(screen.getByTestId("chat-composer-token-counter")).toHaveTextContent(
+      "12k / 200k",
+    );
+  });
+
   it("removes an attachment when its remove (×) button is clicked", async () => {
     const user = userEvent.setup();
     render(<Composer />);

--- a/ui/tandem/src/features/chat/ui/__tests__/Composer.test.tsx
+++ b/ui/tandem/src/features/chat/ui/__tests__/Composer.test.tsx
@@ -19,7 +19,7 @@ describe("Composer", () => {
     await user.keyboard("{Enter}");
 
     expect(onSend).toHaveBeenCalledTimes(1);
-    expect(onSend).toHaveBeenCalledWith("hello world");
+    expect(onSend).toHaveBeenCalledWith("hello world", []);
   });
 
   it("clears the input after submitting", async () => {
@@ -74,5 +74,110 @@ describe("Composer", () => {
 
     expect(onSend).not.toHaveBeenCalled();
     expect(input.value).toBe("line one\nline two");
+  });
+
+  it("renders an attach button and a hidden image-only file input", () => {
+    render(<Composer />);
+
+    const attachButton = screen.getByTestId("chat-composer-attach");
+    expect(attachButton).toBeInTheDocument();
+    expect(attachButton).toHaveAttribute("aria-label", "Attach file");
+
+    const fileInput = screen.getByTestId(
+      "chat-composer-attach-input",
+    ) as HTMLInputElement;
+    expect(fileInput).toBeInTheDocument();
+    expect(fileInput.type).toBe("file");
+    expect(fileInput.accept).toMatch(/^image\//);
+  });
+
+  it("renders an attachment chip after the user picks an image", async () => {
+    const user = userEvent.setup();
+    render(<Composer />);
+    const fileInput = screen.getByTestId(
+      "chat-composer-attach-input",
+    ) as HTMLInputElement;
+
+    const file = new File(["fake-png-bytes"], "screenshot.png", {
+      type: "image/png",
+    });
+    await user.upload(fileInput, file);
+
+    const chip = await screen.findByTestId("chat-composer-attachment-chip");
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveTextContent("screenshot.png");
+  });
+
+  it("calls onSend with text and the attachments array on Enter", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<Composer onSend={onSend} />);
+    const fileInput = screen.getByTestId(
+      "chat-composer-attach-input",
+    ) as HTMLInputElement;
+    const file = new File(["fake-png-bytes"], "diagram.png", {
+      type: "image/png",
+    });
+    await user.upload(fileInput, file);
+    await screen.findByTestId("chat-composer-attachment-chip");
+
+    const input = screen.getByTestId("chat-composer-input");
+    await user.type(input, "look at this");
+    await user.keyboard("{Enter}");
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    const [text, attachments] = onSend.mock.calls[0];
+    expect(text).toBe("look at this");
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]).toMatchObject({
+      name: "diagram.png",
+      mimeType: "image/png",
+    });
+    expect(typeof attachments[0].data).toBe("string");
+    expect(attachments[0].data.length).toBeGreaterThan(0);
+  });
+
+  it("clears attachments after a successful submit", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<Composer onSend={onSend} />);
+    const fileInput = screen.getByTestId(
+      "chat-composer-attach-input",
+    ) as HTMLInputElement;
+    await user.upload(
+      fileInput,
+      new File(["b"], "shot.png", { type: "image/png" }),
+    );
+    await screen.findByTestId("chat-composer-attachment-chip");
+    const input = screen.getByTestId("chat-composer-input");
+    await user.type(input, "go");
+    await user.keyboard("{Enter}");
+
+    expect(
+      screen.queryByTestId("chat-composer-attachment-chip"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("removes an attachment when its remove (×) button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<Composer />);
+    const fileInput = screen.getByTestId(
+      "chat-composer-attach-input",
+    ) as HTMLInputElement;
+
+    const file = new File(["bytes"], "diagram.png", { type: "image/png" });
+    await user.upload(fileInput, file);
+
+    const chip = await screen.findByTestId("chat-composer-attachment-chip");
+    const removeButton = chip.querySelector<HTMLButtonElement>(
+      '[data-testid="chat-composer-attachment-remove"]',
+    );
+    expect(removeButton).not.toBeNull();
+
+    await user.click(removeButton as HTMLButtonElement);
+
+    expect(
+      screen.queryByTestId("chat-composer-attachment-chip"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/tandem/src/features/providers/api/inventory.ts
+++ b/ui/tandem/src/features/providers/api/inventory.ts
@@ -1,0 +1,10 @@
+import type { ProviderInventoryEntryDto } from "@aaif/goose-sdk";
+import { getClient } from "@/shared/api/acpConnection";
+
+export async function getProviderInventory(
+  providerIds: string[] = [],
+): Promise<ProviderInventoryEntryDto[]> {
+  const client = await getClient();
+  const response = await client.goose.GooseProvidersList({ providerIds });
+  return response.entries;
+}


### PR DESCRIPTION
## Summary

Part 2 of Phase 3a (#17) — slices 7b through 11. Wires the streaming pipeline end-to-end and rounds out the empty state / composer with attachments, per-session persona name, the read-only stub footer, and the no-providers banner.

- **Slice 7b** — `useAppStartup` now calls `setNotificationHandler` (and primes `getClient()`) before `loadSessions()`, so real ACP `session_update` events actually reach `chatStore` instead of dead-ending. Without this, slice 7's typing indicator visually worked but streaming was dead at runtime.
- **Slice 8** — Paperclip attach button + hidden image-only file input. Picked images render as removable chips above the textarea; on Enter they flow through `Composer.onSend` → `useChat.send` → `acpSendMessage` as `options.images=[[base64, mimeType], …]`. `Composer.onSend` signature evolved to `(text, attachments)`; `useChat.send` to `(text, attachments?)`.
- **Slice 9** — Active persona/agent name visible per session as a `chat-message-persona-{id}` header above each assistant message body. Source: `chatSessionStore.sessions[].personaId` → `agentStore.personas[].displayName`. Fallback string is **"Tandem"** (not goose2's "Goose"). Per-message persona metadata exists in the type but is intentionally ignored by Timeline in v1.0.
- **Slice 10** — Composer footer is now the v1.0 read-only stub strip: context-folder chip (lucide `Brain`), token counter (gradient bar + `X.Xk / Yk`, success/warning/danger thresholds at 60/80%), MCP-count chip (lucide `Plug` + accent-pill badge). Model picker deferred to Phase 3b per issue.
- **Slice 11** — `ProvidersBanner` (warning style, lucide `AlertTriangle`) renders above the empty-state/timeline branches when no `providerInventoryStore` entry has `configured: true`. Composer textarea + attach button gain `disabled` (chips stay visible — read-only anyway). New `features/providers/api/inventory.ts` wraps `client.goose.GooseProvidersList`; `useAppStartup` calls it as a parallel async on launch so the banner reflects real state.

268 tests pass (12 files changed, ~1.2k lines added).

## Test plan

- [ ] `pnpm --filter tandem test` — 268 tests pass
- [ ] Launch `pnpm --filter tandem tauri dev` with no providers configured → providers banner visible at top of ChatPane, composer textarea + attach button disabled
- [ ] Configure a provider, restart → banner gone, composer enabled
- [ ] In an empty draft tab: type → Enter → message appears in timeline; assistant streams in real time (slice 7b smoke test)
- [ ] Attach an image via paperclip → chip appears → Enter → ACP `prompt()` payload includes the image; chips clear after send
- [ ] Open a session whose `personaId` matches an `agentStore` persona → assistant message header shows that displayName
- [ ] Composer footer shows context chip / gradient token bar / MCP-count chip; thresholds change color past 60%/80%

Closes part 2 of #17 (Part 3 — AI elements port — lands in a separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)