### PR TITLE
Phase 3a Part 2 — wireup + attachments + persona + footer + banner (slices 7b-11)

### DIFF
--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -1,0 +1,5 @@
+# Cursor API key
+# Get one from https://cursor.com/dashboard/integrations
+CURSOR_API_KEY=
+# GitHub personal access token
+GH_TOKEN=

--- a/.sandcastle/.gitignore
+++ b/.sandcastle/.gitignore
@@ -1,0 +1,3 @@
+.env
+logs/
+worktrees/

--- a/.sandcastle/CODING_STANDARDS.md
+++ b/.sandcastle/CODING_STANDARDS.md
@@ -1,0 +1,27 @@
+# Coding Standards
+
+<!-- Customize this file with your project's coding standards.
+     The reviewer agent loads it during code review via @.sandcastle/CODING_STANDARDS.md
+     so these standards are enforced during review without costing tokens during implementation. -->
+
+## Style
+
+<!-- Example:
+- Use camelCase for variables and functions
+- Use PascalCase for classes and types
+- Prefer named exports over default exports
+-->
+
+## Testing
+
+<!-- Example:
+- Every public function must have at least one test
+- Use descriptive test names that explain the expected behavior
+-->
+
+## Architecture
+
+<!-- Example:
+- Keep modules focused on a single responsibility
+- Prefer composition over inheritance
+-->

--- a/.sandcastle/Containerfile
+++ b/.sandcastle/Containerfile
@@ -1,0 +1,35 @@
+FROM node:22-bookworm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+  git \
+  curl \
+  jq \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && apt-get update && apt-get install -y gh \
+  && rm -rf /var/lib/apt/lists/*
+
+# Rename the base image's "node" user (UID 1000) to "agent".
+# This keeps UID 1000 so that --userns=keep-id (Podman) and
+# --user 1000:1000 (Docker) map to the correct home directory owner.
+RUN usermod -d /home/agent -m -l agent node
+USER agent
+
+# Install Cursor CLI (per-user installer — must run as the agent user)
+RUN curl -fsSL https://cursor.com/install | bash
+
+# Add Cursor to PATH
+ENV PATH="/home/agent/.local/bin:$PATH"
+
+WORKDIR /home/agent
+
+# In worktree sandbox mode, Sandcastle bind-mounts the git worktree at /home/agent/workspace
+# and overrides the working directory to /home/agent/workspace at container start.
+# Structure your Dockerfile so that /home/agent/workspace can serve as the project root.
+ENTRYPOINT ["sleep", "infinity"]

--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -1,0 +1,51 @@
+# Context
+
+## Open issues
+
+!`gh issue list --state open --label Sandcastle --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+
+## Recent RALPH commits (last 10)
+
+!`git log --oneline --grep="RALPH" -10`
+
+# Task
+
+You are RALPH — an autonomous coding agent working through GitHub issues one at a time.
+
+## Priority order
+
+Work on issues in this order:
+
+1. **Bug fixes** — broken behaviour affecting users
+2. **Tracer bullets** — thin end-to-end slices that prove an approach works
+3. **Polish** — improving existing functionality (error messages, UX, docs)
+4. **Refactors** — internal cleanups with no user-visible change
+
+Pick the highest-priority open issue that is not blocked by another open issue.
+
+## Workflow
+
+1. **Explore** — read the issue carefully. Pull in the parent PRD if referenced. Read the relevant source files and tests before writing any code.
+2. **Plan** — decide what to change and why. Keep the change as small as possible.
+3. **Execute** — use RGR (Red → Green → Repeat → Refactor): write a failing test first, then write the implementation to pass it.
+4. **Verify** — run `npm run typecheck` and `npm run test` before committing. Fix any failures before proceeding.
+5. **Commit** — make a single git commit. The message MUST:
+   - Start with `RALPH:` prefix
+   - Include the task completed and any PRD reference
+   - List key decisions made
+   - List files changed
+   - Note any blockers for the next iteration
+6. **Close** — close the issue with `gh issue close <ID> --comment "Completed by Sandcastle"` explaining what was done.
+
+## Rules
+
+- Work on **one issue per iteration**. Do not attempt multiple issues in a single iteration.
+- Do not close an issue until you have committed the fix and verified tests pass.
+- Do not leave commented-out code or TODO comments in committed code.
+- If you are blocked (missing context, failing tests you cannot fix, external dependency), leave a comment on the issue and move on — do not close it.
+
+# Done
+
+When all actionable issues are complete (or you are blocked on all remaining ones), output the completion signal:
+
+<promise>COMPLETE</promise>

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -1,0 +1,116 @@
+// Sequential Reviewer — implement-then-review loop
+//
+// This template drives a two-phase workflow per issue:
+//   Phase 1 (Implement): A sonnet agent picks an open GitHub issue, works on it
+//                        on a dedicated branch, commits the changes, and signals
+//                        completion.
+//   Phase 2 (Review):    A second sonnet agent reviews the branch diff and either
+//                        approves it or makes corrections directly on the branch.
+//
+// The outer loop repeats up to MAX_ITERATIONS times, processing one issue per
+// iteration. This is a middle-complexity option between the simple-loop (no review
+// gate) and the parallel-planner (concurrent execution with a planning phase).
+//
+// Usage:
+//   npx tsx .sandcastle/main.mts
+// Or add to package.json:
+//   "scripts": { "sandcastle": "npx tsx .sandcastle/main.mts" }
+
+import * as sandcastle from "@ai-hero/sandcastle";
+import { podman } from "@ai-hero/sandcastle/sandboxes/podman";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+// Maximum number of implement→review cycles to run before stopping.
+// Each cycle works on one issue. Raise this to process more issues per run.
+const MAX_ITERATIONS = 1;
+
+// Hooks run inside the sandbox before the agent starts each iteration.
+//   1. npm install — sandcastle launcher deps at the repo root.
+//   2. pnpm install in ui/ — the actual application (pnpm workspace).
+//      Bootstrapped via npx so we don't depend on a global pnpm in the image.
+const hooks = {
+  sandbox: {
+    onSandboxReady: [
+      { command: "npm install" },
+      {
+        command: "cd ui && CI=true npx --yes pnpm@10.33.0 install",
+        timeoutMs: 15 * 60 * 1000,
+      },
+    ],
+  },
+};
+
+// Copy node_modules from the host into the worktree before each sandbox
+// starts. Avoids a full npm install from scratch; the hook above handles
+// platform-specific binaries and any packages added since the last copy.
+const copyToWorktree = ["node_modules"];
+
+// ---------------------------------------------------------------------------
+// Main loop
+// ---------------------------------------------------------------------------
+
+for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
+  console.log(`\n=== Iteration ${iteration}/${MAX_ITERATIONS} ===\n`);
+
+  // -------------------------------------------------------------------------
+  // Phase 1: Implement
+  //
+  // A sonnet agent picks the next open GitHub issue, creates a branch, writes
+  // the implementation (using RGR: Red → Green → Repeat → Refactor), and
+  // commits the result.
+  //
+  // The agent signals completion via <promise>COMPLETE</promise> when done.
+  // The result contains the branch name the agent worked on.
+  // -------------------------------------------------------------------------
+  const implement = await sandcastle.run({
+    hooks,
+    copyToWorktree,
+    sandbox: podman(),
+    branchStrategy: { type: "merge-to-head" },
+    name: "implementer",
+    maxIterations: 100,
+    agent: sandcastle.cursor("claude-4.6-opus"),
+    promptFile: "./.sandcastle/implement-prompt.md",
+  });
+
+  // Extract the branch the agent worked on so the reviewer can target it.
+  const branch = implement.branch;
+
+  if (!implement.commits.length) {
+    console.log("Implementation agent made no commits. Skipping review.");
+    continue;
+  }
+
+  console.log(`\nImplementation complete on branch: ${branch}`);
+  console.log(`Commits: ${implement.commits.length}`);
+
+  // -------------------------------------------------------------------------
+  // Phase 2: Review
+  //
+  // A second sonnet agent reviews the diff of the branch produced by Phase 1.
+  // It uses the {{BRANCH}} prompt argument to inspect the right branch, and
+  // either approves or makes corrections directly on the branch.
+  // -------------------------------------------------------------------------
+  await sandcastle.run({
+    hooks,
+    copyToWorktree,
+    sandbox: podman(),
+    branchStrategy: { type: "branch", branch },
+    name: "reviewer",
+    maxIterations: 1,
+    agent: sandcastle.cursor("claude-4.6-opus"),
+    promptFile: "./.sandcastle/review-prompt.md",
+    // Prompt arguments substitute {{BRANCH}} in review-prompt.md before the
+    // agent sees the prompt.
+    promptArgs: {
+      BRANCH: branch,
+    },
+  });
+
+  console.log("\nReview complete.");
+}
+
+console.log("\nAll done.");

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -1,0 +1,55 @@
+# TASK
+
+Review the code changes on branch `{{BRANCH}}` and improve code clarity, consistency, and maintainability while preserving exact functionality.
+
+# CONTEXT
+
+## Branch diff
+
+!`git diff {{SOURCE_BRANCH}}...{{BRANCH}}`
+
+## Commits on this branch
+
+!`git log {{SOURCE_BRANCH}}..{{BRANCH}} --oneline`
+
+# REVIEW PROCESS
+
+1. **Understand the change**: Read the diff and commits above to understand the intent.
+
+2. **Analyze for improvements**: Look for opportunities to:
+   - Reduce unnecessary complexity and nesting
+   - Eliminate redundant code and abstractions
+   - Improve readability through clear variable and function names
+   - Consolidate related logic
+   - Remove unnecessary comments that describe obvious code
+   - Avoid nested ternary operators - prefer switch statements or if/else chains
+   - Choose clarity over brevity - explicit code is often better than overly compact code
+
+3. **Check correctness**:
+   - Does the implementation match the intent? Are edge cases handled?
+   - Are new/changed behaviours covered by tests?
+   - Are there unsafe casts, `any` types, or unchecked assumptions?
+   - Does the change introduce injection vulnerabilities, credential leaks, or other security issues?
+
+4. **Maintain balance**: Avoid over-simplification that could:
+   - Reduce code clarity or maintainability
+   - Create overly clever solutions that are hard to understand
+   - Combine too many concerns into single functions or components
+   - Remove helpful abstractions that improve code organization
+   - Make the code harder to debug or extend
+
+5. **Apply project standards**: Follow the coding standards defined in @.sandcastle/CODING_STANDARDS.md
+
+6. **Preserve functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
+
+# EXECUTION
+
+If you find improvements to make:
+
+1. Make the changes directly on this branch
+2. Run tests and type checking to ensure nothing is broken
+3. Commit describing the refinements
+
+If the code is already clean and well-structured, do nothing.
+
+Once complete, output <promise>COMPLETE</promise>.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,970 @@
+{
+  "name": "tandem",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@ai-hero/sandcastle": "github:larmax82/sandcastle#v0.5.7-cursor.9"
+      }
+    },
+    "node_modules/@ai-hero/sandcastle": {
+      "version": "0.5.7",
+      "resolved": "git+ssh://git@github.com/larmax82/sandcastle.git#51081df7e22d84c00959be144815b40869b4a0dc",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/prompts": "^1.1.0",
+        "@effect/cli": "^0.74.0",
+        "@effect/platform": "^0.95.0",
+        "@effect/platform-node": "^0.105.0",
+        "@effect/printer": "^0.48.0",
+        "@effect/printer-ansi": "^0.48.0",
+        "effect": "^3.20.0"
+      },
+      "bin": {
+        "sandcastle": "dist/main.js"
+      },
+      "peerDependencies": {
+        "@daytona/sdk": "^0.164.0",
+        "@vercel/sandbox": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@daytona/sdk": {
+          "optional": true
+        },
+        "@vercel/sandbox": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.3.0.tgz",
+      "integrity": "sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.3.0",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@effect/cli": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@effect/cli/-/cli-0.74.0.tgz",
+      "integrity": "sha512-vjMJWJWQ2zMRVcZJj2ZGr7vFgVoX6lsCuqAsNiN2ndWZAidkEJ6g1Euuib2V2nTXeWvRyd3FY2Fw2UvX48Uenw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^4.1.3",
+        "toml": "^3.0.0",
+        "yaml": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.95.0",
+        "@effect/printer": "^0.48.0",
+        "@effect/printer-ansi": "^0.48.0",
+        "effect": "^3.20.0"
+      }
+    },
+    "node_modules/@effect/cluster": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@effect/cluster/-/cluster-0.57.0.tgz",
+      "integrity": "sha512-VjZoZ4hmgDb0GtGjktypTk/nArA3ntsXU2O9vOBzDjJLRKVBt7IS0/cllHrHwK5Jxkfz86B2k+Prw4/+nrLFlw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "kubernetes-types": "^1.30.0"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.95.0",
+        "@effect/rpc": "^0.74.0",
+        "@effect/sql": "^0.50.0",
+        "@effect/workflow": "^0.17.0",
+        "effect": "^3.20.0"
+      }
+    },
+    "node_modules/@effect/experimental": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@effect/experimental/-/experimental-0.59.0.tgz",
+      "integrity": "sha512-XqdBpIH5VLlkRxKlyPYp8TAYUeBPjoWYgtrxDebDab14K4kkrpkHk0ZsmmOiQUZ+LY5veRn/PBSogXor9gtPqg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "uuid": "^11.0.3"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.95.0",
+        "effect": "^3.20.0",
+        "ioredis": "^5",
+        "lmdb": "^3"
+      },
+      "peerDependenciesMeta": {
+        "ioredis": {
+          "optional": true
+        },
+        "lmdb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@effect/platform": {
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.95.0.tgz",
+      "integrity": "sha512-WDlRiWRSWlmhCPq09bvAofK0qr5vM4yNklXjoJdZHmugKRRTpN/Okn3ODnjgM/Kb/4hjMrRyrsUeH/Brieq7KA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-my-way-ts": "^0.1.6",
+        "msgpackr": "^1.11.4",
+        "multipasta": "^0.2.7"
+      },
+      "peerDependencies": {
+        "effect": "^3.20.0"
+      }
+    },
+    "node_modules/@effect/platform-node": {
+      "version": "0.105.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node/-/platform-node-0.105.0.tgz",
+      "integrity": "sha512-6JxOLqLJMm+m1ZQavIb75S7YJ4fRvrDaYUZ4rqv2IMq5ZK9HVaU/LeejE9tip9zAG9yNM/6mn183iiIV/xge5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@effect/platform-node-shared": "^0.58.0",
+        "mime": "^3.0.0",
+        "undici": "^7.10.0",
+        "ws": "^8.18.2"
+      },
+      "peerDependencies": {
+        "@effect/cluster": "^0.57.0",
+        "@effect/platform": "^0.95.0",
+        "@effect/rpc": "^0.74.0",
+        "@effect/sql": "^0.50.0",
+        "effect": "^3.20.0"
+      }
+    },
+    "node_modules/@effect/platform-node-shared": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-0.58.0.tgz",
+      "integrity": "sha512-kl8ejYM1xvjRlk+4/R1YzB6A3E3hVWY4jIfEl21uu4S43V0S15gHvcur7iMIEXfJTX1a25EKF+Buef+Yv5wZZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/watcher": "^2.5.1",
+        "multipasta": "^0.2.7",
+        "ws": "^8.18.2"
+      },
+      "peerDependencies": {
+        "@effect/cluster": "^0.57.0",
+        "@effect/platform": "^0.95.0",
+        "@effect/rpc": "^0.74.0",
+        "@effect/sql": "^0.50.0",
+        "effect": "^3.20.0"
+      }
+    },
+    "node_modules/@effect/printer": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@effect/printer/-/printer-0.48.0.tgz",
+      "integrity": "sha512-f/+QVyqACuLkoB+HDDX2XxloslmgMDL+C6ecHBV0cB0zJzJmLCOybwOkRcCI2xJ/DWHEIpoRyvq+Bfdza0AIrA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@effect/typeclass": "^0.39.0",
+        "effect": "^3.20.0"
+      }
+    },
+    "node_modules/@effect/printer-ansi": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@effect/printer-ansi/-/printer-ansi-0.48.0.tgz",
+      "integrity": "sha512-CzQ5kiomjR9DZ6LPfKAaWmys6JU65c2Q/VQcTKRK4RfaDWeTAehpAVmgOIyKSPkcr9XBhjo2cJx4xyZ4E5nN7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@effect/printer": "^0.48.0"
+      },
+      "peerDependencies": {
+        "@effect/typeclass": "^0.39.0",
+        "effect": "^3.20.0"
+      }
+    },
+    "node_modules/@effect/rpc": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@effect/rpc/-/rpc-0.74.0.tgz",
+      "integrity": "sha512-EV/cHQqJxLtY+RTlPlVQU1KyTzml1wFne+Sh91RacGRRVh6uTm4UdhRh9TNtbYHD4rM9yD3T6zqUgKr0AH8MvQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "msgpackr": "^1.11.4"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.95.0",
+        "effect": "^3.20.0"
+      }
+    },
+    "node_modules/@effect/sql": {
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@effect/sql/-/sql-0.50.0.tgz",
+      "integrity": "sha512-sOTzsC+ICASgSmX1RITYo6ut7ZbkX+hMG6YagJEyhtptxco9MgSflpF/ix/L92haJ+YTS5Zur/Dm2bDNfVes4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "uuid": "^11.0.3"
+      },
+      "peerDependencies": {
+        "@effect/experimental": "^0.59.0",
+        "@effect/platform": "^0.95.0",
+        "effect": "^3.20.0"
+      }
+    },
+    "node_modules/@effect/typeclass": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@effect/typeclass/-/typeclass-0.39.0.tgz",
+      "integrity": "sha512-V8qGpm4BTMS4pW9e7aCdxC0sy/TYsdxmnpWtokkNWnggZ6kvh1Psp3AfUuuZLyNmUk4T+lYB/ItEsga/+hryig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "effect": "^3.20.0"
+      }
+    },
+    "node_modules/@effect/workflow": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@effect/workflow/-/workflow-0.17.0.tgz",
+      "integrity": "sha512-JiayvFTTMrp36P0cVFcgu6Nb7ZJxQv+FRqs3DPORkVAcCZlWOKa3KyuYebN3qZbRsmLzS7cxuC8BAeMuqb+WaQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@effect/experimental": "^0.59.0",
+        "@effect/platform": "^0.95.0",
+        "@effect/rpc": "^0.74.0",
+        "effect": "^3.20.0"
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.2.tgz",
+      "integrity": "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/msgpackr": {
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.12.tgz",
+      "integrity": "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "devDependencies": {
+    "@ai-hero/sandcastle": "github:larmax82/sandcastle#v0.5.7-cursor.9"
+  },
+  "scripts": {
+    "sandcastle": "npx tsx .sandcastle/main.mts"
+  }
+}

--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -31,6 +31,8 @@ import { AppShell } from "@/app/AppShell";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import { useToastStore } from "@/features/toasts/toastStore";
+import { useAgentStore } from "@/features/agents/stores/agentStore";
+import { useProviderInventoryStore } from "@/features/providers/stores/providerInventoryStore";
 import {
   DRAFT_TAB_PREFIX,
   useTabsStore,
@@ -53,6 +55,10 @@ describe("AppShell", () => {
     useChatStore.setState({ messagesBySession: {}, sessionStateById: {} });
     useToastStore.setState({ toasts: [] });
     useTabsStore.setState({ openIds: [], activeId: null });
+    useAgentStore.setState({ personas: [] });
+    useProviderInventoryStore.getState().setEntries([
+      { providerId: "openai", configured: true, models: [] } as never,
+    ]);
     localStorage.clear();
     mockAcpCreateSession.mockReset();
     mockAcpSendMessage.mockReset();
@@ -655,7 +661,204 @@ describe("AppShell", () => {
     expect(screen.getByTestId("tab-abc")).toBeInTheDocument();
     await user.click(screen.getByTestId("tab-close-abc"));
     expect(screen.queryByTestId("tab-abc")).not.toBeInTheDocument();
-    // Session still in history
     expect(screen.getByTestId("session-row-abc")).toBeInTheDocument();
+  });
+
+  describe("persona name on assistant messages (slice 9)", () => {
+    it("renders 'Tandem' as fallback persona name on assistant messages", () => {
+      seedTabs(["sess-1"], "sess-1");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-1",
+            title: "Chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 2,
+          },
+        ],
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-1": [
+            {
+              id: "u1",
+              role: "user",
+              created: 1,
+              content: [{ type: "text", text: "hi" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+            {
+              id: "a1",
+              role: "assistant",
+              created: 2,
+              content: [{ type: "text", text: "hello" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+      });
+
+      render(<AppShell />);
+
+      const personaHeader = screen.getByTestId("chat-message-persona-a1");
+      expect(personaHeader).toHaveTextContent("Tandem");
+    });
+
+    it("renders the persona display name when session has a personaId and agentStore has a matching persona", () => {
+      seedTabs(["sess-1"], "sess-1");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-1",
+            title: "Chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 2,
+            personaId: "persona-abc",
+          },
+        ],
+      });
+      useAgentStore.setState({
+        personas: [
+          {
+            id: "persona-abc",
+            displayName: "Code Wizard",
+            systemPrompt: "",
+            isBuiltin: true,
+            createdAt: "",
+            updatedAt: "",
+          },
+        ],
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-1": [
+            {
+              id: "u1",
+              role: "user",
+              created: 1,
+              content: [{ type: "text", text: "hi" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+            {
+              id: "a1",
+              role: "assistant",
+              created: 2,
+              content: [{ type: "text", text: "hello" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+      });
+
+      render(<AppShell />);
+
+      const personaHeader = screen.getByTestId("chat-message-persona-a1");
+      expect(personaHeader).toHaveTextContent("Code Wizard");
+    });
+
+    it("does not render a persona header on user messages", () => {
+      seedTabs(["sess-1"], "sess-1");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-1",
+            title: "Chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+          },
+        ],
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-1": [
+            {
+              id: "u1",
+              role: "user",
+              created: 1,
+              content: [{ type: "text", text: "hi" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+      });
+
+      render(<AppShell />);
+
+      expect(
+        screen.queryByTestId("chat-message-persona-u1"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("composer footer chips (slice 10)", () => {
+    it("renders context folder, token counter, and MCP count chips in the composer footer", () => {
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      seedTabs([draftId], draftId);
+
+      render(<AppShell />);
+
+      expect(
+        screen.getByTestId("chat-composer-context-folder"),
+      ).toHaveTextContent("Default");
+      expect(
+        screen.getByTestId("chat-composer-token-counter"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("chat-composer-mcp-count"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("providers banner (slice 11)", () => {
+    it("renders the ProvidersBanner when no providers have configured: true", () => {
+      useProviderInventoryStore.getState().setEntries([]);
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      seedTabs([draftId], draftId);
+
+      render(<AppShell />);
+
+      const banner = screen.getByTestId("providers-banner");
+      expect(banner).toBeInTheDocument();
+      expect(banner).toHaveTextContent(
+        "No providers configured. Open goose2 to set up an API key, then restart Tandem.",
+      );
+    });
+
+    it("does not render the banner when a configured provider exists", () => {
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      seedTabs([draftId], draftId);
+
+      render(<AppShell />);
+
+      expect(screen.queryByTestId("providers-banner")).not.toBeInTheDocument();
+    });
+
+    it("disables the composer when no providers are configured", () => {
+      useProviderInventoryStore.getState().setEntries([]);
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      seedTabs([draftId], draftId);
+
+      render(<AppShell />);
+
+      const textarea = screen.getByTestId(
+        "chat-composer-input",
+      ) as HTMLTextAreaElement;
+      expect(textarea.disabled).toBe(true);
+    });
+
+    it("enables the composer when providers are configured", () => {
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      seedTabs([draftId], draftId);
+
+      render(<AppShell />);
+
+      const textarea = screen.getByTestId(
+        "chat-composer-input",
+      ) as HTMLTextAreaElement;
+      expect(textarea.disabled).toBe(false);
+    });
   });
 });

--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 
 vi.mock("@/shared/api/acpConnection", () => ({
   getClient: vi.fn(() => new Promise(() => {})),
+  setNotificationHandler: vi.fn(),
 }));
 
 const { mockAcpCreateSession, mockAcpSendMessage, mockResolvePath } =

--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -591,6 +591,48 @@ describe("AppShell", () => {
         "hello world",
       );
     });
+
+    it("includes attached image in the ACP prompt payload as options.images", async () => {
+      const user = userEvent.setup();
+      const draftId = `${DRAFT_TAB_PREFIX}img`;
+      seedTabs([draftId], draftId);
+
+      mockAcpCreateSession.mockResolvedValue({
+        sessionId: "real-session-img",
+      });
+
+      render(<AppShell />);
+
+      const fileInput = screen.getByTestId(
+        "chat-composer-attach-input",
+      ) as HTMLInputElement;
+      const file = new File(["fake-png-bytes"], "diagram.png", {
+        type: "image/png",
+      });
+      await user.upload(fileInput, file);
+      await screen.findByTestId("chat-composer-attachment-chip");
+
+      const input = screen.getByTestId("chat-composer-input");
+      await user.type(input, "look at this");
+      await user.keyboard("{Enter}");
+
+      await waitFor(
+        () => {
+          expect(mockAcpSendMessage).toHaveBeenCalled();
+        },
+        { timeout: 3000 },
+      );
+
+      const [sessionId, text, options] = mockAcpSendMessage.mock.calls[0];
+      expect(sessionId).toBe("real-session-img");
+      expect(text).toBe("look at this");
+      expect(options).toBeDefined();
+      expect(options.images).toHaveLength(1);
+      const [data, mimeType] = options.images[0];
+      expect(typeof data).toBe("string");
+      expect(data.length).toBeGreaterThan(0);
+      expect(mimeType).toBe("image/png");
+    });
   });
 
   it("clicking a tab close button removes the tab but keeps the session in history", async () => {

--- a/ui/tandem/src/app/hooks/__tests__/useAppStartup.test.ts
+++ b/ui/tandem/src/app/hooks/__tests__/useAppStartup.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+
+const { mockSetNotificationHandler, mockGetClient } = vi.hoisted(() => ({
+  mockSetNotificationHandler: vi.fn(),
+  mockGetClient: vi.fn(),
+}));
+
+vi.mock("@/shared/api/acpConnection", () => ({
+  setNotificationHandler: mockSetNotificationHandler,
+  getClient: mockGetClient,
+}));
+
+vi.mock("@/shared/api/acp", async (importActual) => {
+  const actual = await importActual<typeof import("@/shared/api/acp")>();
+  return {
+    ...actual,
+    acpListSessions: vi.fn(async () => []),
+  };
+});
+
+import { useAppStartup } from "@/app/hooks/useAppStartup";
+import { useChatStore } from "@/features/chat/stores/chatStore";
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import {
+  registerSession,
+  unregisterSession,
+} from "@/shared/api/acpSessionTracker";
+import type { AcpNotificationHandler } from "@/shared/api/acpConnection";
+
+describe("useAppStartup ACP notification wire-up (slice 7b)", () => {
+  beforeEach(() => {
+    mockSetNotificationHandler.mockReset();
+    mockGetClient.mockReset();
+    mockGetClient.mockResolvedValue({});
+    useChatStore.setState({
+      messagesBySession: {},
+      sessionStateById: {},
+      queuedMessageBySession: {},
+      draftsBySession: {},
+      activeSessionId: null,
+      isConnected: false,
+      loadingSessionIds: new Set<string>(),
+      scrollTargetMessageBySession: {},
+    });
+    useChatSessionStore.setState({
+      sessions: [],
+      activeSessionId: null,
+      hasHydratedSessions: false,
+    });
+  });
+
+  afterEach(() => {
+    unregisterSession("local-session-7b", "goose-session-7b");
+  });
+
+  it("routes a SessionNotification to chatStore.messagesBySession", async () => {
+    renderHook(() => useAppStartup());
+
+    await waitFor(() => {
+      expect(mockSetNotificationHandler).toHaveBeenCalledTimes(1);
+    });
+
+    const handler = mockSetNotificationHandler.mock.calls[0]?.[0] as
+      | AcpNotificationHandler
+      | undefined;
+    expect(handler).toBeDefined();
+    expect(typeof handler?.handleSessionNotification).toBe("function");
+
+    registerSession(
+      "local-session-7b",
+      "goose-session-7b",
+      "goose",
+      "/tmp/test",
+    );
+
+    const notification: SessionNotification = {
+      sessionId: "goose-session-7b",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "assistant-msg-1",
+        content: { type: "text", text: "hello from agent" },
+      },
+    } as SessionNotification;
+
+    await handler!.handleSessionNotification(notification);
+
+    const messages =
+      useChatStore.getState().messagesBySession["local-session-7b"];
+    expect(messages).toBeDefined();
+    expect(messages).toHaveLength(1);
+    expect(messages?.[0]?.id).toBe("assistant-msg-1");
+    expect(messages?.[0]?.role).toBe("assistant");
+    const textBlock = messages?.[0]?.content[0];
+    expect(textBlock?.type).toBe("text");
+    if (textBlock?.type === "text") {
+      expect(textBlock.text).toBe("hello from agent");
+    }
+  });
+});

--- a/ui/tandem/src/app/hooks/useAppStartup.ts
+++ b/ui/tandem/src/app/hooks/useAppStartup.ts
@@ -1,12 +1,27 @@
 import { useEffect } from "react";
 
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import {
+  getClient,
+  setNotificationHandler,
+} from "@/shared/api/acpConnection";
+import notificationHandler from "@/shared/api/acpNotificationHandler";
 
-// Phase 2 startup: hydrate the session list so the LeftPane history populates
-// from goose serve. Phase 3 will expand this to load provider inventory,
-// personas, etc. — see ui/goose2/src/app/hooks/useAppStartup.ts for the shape.
+// Phase 3a startup: register the chat notification handler so ACP
+// session_update events flow into chatStore, then prime the ACP client and
+// hydrate the session list. Phase 3b+ will expand this with provider
+// inventory, personas, etc. — see ui/goose2/src/app/hooks/useAppStartup.ts
+// for the fully-loaded shape.
 export function useAppStartup(): void {
   useEffect(() => {
-    void useChatSessionStore.getState().loadSessions();
+    void (async () => {
+      try {
+        setNotificationHandler(notificationHandler);
+        await getClient();
+      } catch (err) {
+        console.error("Failed to initialize ACP connection:", err);
+      }
+      void useChatSessionStore.getState().loadSessions();
+    })();
   }, []);
 }

--- a/ui/tandem/src/app/hooks/useAppStartup.ts
+++ b/ui/tandem/src/app/hooks/useAppStartup.ts
@@ -1,17 +1,14 @@
 import { useEffect } from "react";
 
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import { useProviderInventoryStore } from "@/features/providers/stores/providerInventoryStore";
 import {
   getClient,
   setNotificationHandler,
 } from "@/shared/api/acpConnection";
 import notificationHandler from "@/shared/api/acpNotificationHandler";
+import { getProviderInventory } from "@/features/providers/api/inventory";
 
-// Phase 3a startup: register the chat notification handler so ACP
-// session_update events flow into chatStore, then prime the ACP client and
-// hydrate the session list. Phase 3b+ will expand this with provider
-// inventory, personas, etc. — see ui/goose2/src/app/hooks/useAppStartup.ts
-// for the fully-loaded shape.
 export function useAppStartup(): void {
   useEffect(() => {
     void (async () => {
@@ -22,6 +19,19 @@ export function useAppStartup(): void {
         console.error("Failed to initialize ACP connection:", err);
       }
       void useChatSessionStore.getState().loadSessions();
+      void loadProviderInventory();
     })();
   }, []);
+}
+
+async function loadProviderInventory(): Promise<void> {
+  try {
+    useProviderInventoryStore.getState().setLoading(true);
+    const entries = await getProviderInventory();
+    useProviderInventoryStore.getState().setEntries(entries);
+  } catch (err) {
+    console.error("Failed to load provider inventory:", err);
+  } finally {
+    useProviderInventoryStore.getState().setLoading(false);
+  }
 }

--- a/ui/tandem/src/features/chat/hooks/__tests__/useChat.test.ts
+++ b/ui/tandem/src/features/chat/hooks/__tests__/useChat.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 
+vi.mock("@/shared/api/acpConnection", () => ({
+  getClient: vi.fn(() => new Promise(() => {})),
+  setNotificationHandler: vi.fn(),
+}));
+
 const { mockAcpSendMessage, mockResolvePath } = vi.hoisted(() => ({
   mockAcpSendMessage: vi.fn(),
   mockResolvePath: vi.fn(),

--- a/ui/tandem/src/features/chat/hooks/__tests__/useChat.test.ts
+++ b/ui/tandem/src/features/chat/hooks/__tests__/useChat.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const { mockAcpSendMessage, mockResolvePath } = vi.hoisted(() => ({
+  mockAcpSendMessage: vi.fn(),
+  mockResolvePath: vi.fn(),
+}));
+
+vi.mock("@/shared/api/acp", async (importActual) => {
+  const actual = await importActual<typeof import("@/shared/api/acp")>();
+  return {
+    ...actual,
+    acpSendMessage: mockAcpSendMessage,
+  };
+});
+
+vi.mock("@/shared/api/pathResolver", () => ({
+  resolvePath: mockResolvePath,
+}));
+
+import { useChat } from "@/features/chat/hooks/useChat";
+import { useChatStore } from "@/features/chat/stores/chatStore";
+
+describe("useChat (slice 8.5)", () => {
+  beforeEach(() => {
+    mockAcpSendMessage.mockReset();
+    mockAcpSendMessage.mockResolvedValue(undefined);
+    mockResolvePath.mockReset();
+    mockResolvePath.mockResolvedValue({ path: "/home/test/.goose/artifacts" });
+    useChatStore.setState({
+      messagesBySession: {},
+      sessionStateById: {},
+      queuedMessageBySession: {},
+      draftsBySession: {},
+      activeSessionId: null,
+      isConnected: false,
+      loadingSessionIds: new Set<string>(),
+      scrollTargetMessageBySession: {},
+    });
+  });
+
+  it("forwards image attachments to acpSendMessage as options.images", async () => {
+    const sessionId = "real-session-abc";
+    const { result } = renderHook(() => useChat(sessionId));
+
+    await act(async () => {
+      await result.current.send("look at this", [
+        {
+          name: "diagram.png",
+          mimeType: "image/png",
+          data: "BASE64DATA",
+        },
+      ]);
+    });
+
+    expect(mockAcpSendMessage).toHaveBeenCalledTimes(1);
+    const [callSessionId, callText, callOptions] =
+      mockAcpSendMessage.mock.calls[0];
+    expect(callSessionId).toBe(sessionId);
+    expect(callText).toBe("look at this");
+    expect(callOptions).toMatchObject({
+      images: [["BASE64DATA", "image/png"]],
+    });
+  });
+
+  it("does not pass options.images when no attachments are provided", async () => {
+    const sessionId = "real-session-def";
+    const { result } = renderHook(() => useChat(sessionId));
+
+    await act(async () => {
+      await result.current.send("hi");
+    });
+
+    expect(mockAcpSendMessage).toHaveBeenCalledTimes(1);
+    const call = mockAcpSendMessage.mock.calls[0];
+    expect(call).toEqual([sessionId, "hi"]);
+  });
+});

--- a/ui/tandem/src/features/chat/hooks/useChat.ts
+++ b/ui/tandem/src/features/chat/hooks/useChat.ts
@@ -9,6 +9,7 @@ import {
   useTabsStore,
 } from "@/features/tabs/stores/tabsStore";
 import { createUserMessage } from "@/shared/types/messages";
+import type { ComposerAttachment } from "@/features/chat/ui/Composer";
 
 const isDraftId = (id: string) => id.startsWith(DRAFT_TAB_PREFIX);
 
@@ -18,7 +19,7 @@ async function defaultWorkingDir(): Promise<string> {
 }
 
 export interface UseChatResult {
-  send: (text: string) => Promise<void>;
+  send: (text: string, attachments?: ComposerAttachment[]) => Promise<void>;
   hasMessages: boolean;
 }
 
@@ -28,7 +29,7 @@ export function useChat(tabId: string | null): UseChatResult {
   );
 
   const send = useCallback(
-    async (text: string) => {
+    async (text: string, attachments?: ComposerAttachment[]) => {
       if (!tabId) return;
 
       let sessionId = tabId;
@@ -42,7 +43,15 @@ export function useChat(tabId: string | null): UseChatResult {
       }
 
       useChatStore.getState().addMessage(sessionId, createUserMessage(text));
-      await acpSendMessage(sessionId, text);
+      if (attachments && attachments.length > 0) {
+        const images: [string, string][] = attachments.map((a) => [
+          a.data,
+          a.mimeType,
+        ]);
+        await acpSendMessage(sessionId, text, { images });
+      } else {
+        await acpSendMessage(sessionId, text);
+      }
     },
     [tabId],
   );

--- a/ui/tandem/src/features/chat/ui/ChatPane.tsx
+++ b/ui/tandem/src/features/chat/ui/ChatPane.tsx
@@ -1,15 +1,40 @@
 import { useChat } from "@/features/chat/hooks/useChat";
+import { useChatStore } from "@/features/chat/stores/chatStore";
 import { Composer } from "@/features/chat/ui/Composer";
 import { EmptyState } from "@/features/chat/ui/EmptyState";
+import { ProvidersBanner } from "@/features/chat/ui/ProvidersBanner";
 import { Timeline } from "@/features/chat/ui/Timeline";
+import { useProviderInventoryStore } from "@/features/providers/stores/providerInventoryStore";
 import { useTabsStore } from "@/features/tabs/stores/tabsStore";
+
+function useHasConfiguredProvider(): boolean {
+  return useProviderInventoryStore((s) => {
+    for (const entry of s.entries.values()) {
+      if ((entry as Record<string, unknown>).configured) return true;
+    }
+    return false;
+  });
+}
 
 export const ChatPane = () => {
   const activeTabId = useTabsStore((s) => s.activeId);
   const { send, hasMessages } = useChat(activeTabId);
+  const hasConfiguredProvider = useHasConfiguredProvider();
+  const showBanner = !hasConfiguredProvider;
+
+  const tokenState = useChatStore(
+    (s) => (activeTabId ? s.sessionStateById[activeTabId]?.tokenState : undefined),
+  );
+
+  const composerDisabled = !hasConfiguredProvider;
 
   if (!activeTabId || !hasMessages) {
-    return <EmptyState onSend={send} />;
+    return (
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
+        {showBanner && <ProvidersBanner />}
+        <EmptyState onSend={send} composerDisabled={composerDisabled} />
+      </div>
+    );
   }
 
   return (
@@ -17,6 +42,7 @@ export const ChatPane = () => {
       data-testid="chat-active"
       style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}
     >
+      {showBanner && <ProvidersBanner />}
       <Timeline sessionId={activeTabId} />
       <div
         style={{
@@ -27,7 +53,12 @@ export const ChatPane = () => {
           justifyContent: "center",
         }}
       >
-        <Composer onSend={send} />
+        <Composer
+          onSend={send}
+          disabled={composerDisabled}
+          tokenUsed={tokenState?.accumulatedTotal ?? 0}
+          tokenLimit={tokenState?.contextLimit ?? 0}
+        />
       </div>
     </div>
   );

--- a/ui/tandem/src/features/chat/ui/Composer.tsx
+++ b/ui/tandem/src/features/chat/ui/Composer.tsx
@@ -1,8 +1,37 @@
-import { useState, type KeyboardEvent } from "react";
+import {
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from "react";
+import { FileText, Paperclip, X } from "lucide-react";
+
+export interface ComposerAttachment {
+  name: string;
+  mimeType: string;
+  data: string;
+}
 
 export interface ComposerProps {
   placeholder?: string;
-  onSend?: (text: string) => void;
+  onSend?: (text: string, attachments: ComposerAttachment[]) => void;
+}
+
+function readAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== "string") {
+        reject(new Error("FileReader result was not a string"));
+        return;
+      }
+      const comma = result.indexOf(",");
+      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
 }
 
 export const Composer = ({
@@ -10,14 +39,31 @@ export const Composer = ({
   onSend,
 }: ComposerProps) => {
   const [value, setValue] = useState("");
+  const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    e.target.value = "";
+    if (files.length === 0) return;
+    const next = await Promise.all(
+      files.map(async (file) => ({
+        name: file.name,
+        mimeType: file.type || "application/octet-stream",
+        data: await readAsBase64(file),
+      })),
+    );
+    setAttachments((prev) => [...prev, ...next]);
+  };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       const trimmed = value.trim();
       if (!trimmed) return;
-      onSend?.(trimmed);
+      onSend?.(trimmed, attachments);
       setValue("");
+      setAttachments([]);
     }
   };
 
@@ -36,6 +82,59 @@ export const Composer = ({
         gap: 8,
       }}
     >
+      {attachments.length > 0 && (
+        <div
+          data-testid="chat-composer-attachments"
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 6,
+          }}
+        >
+          {attachments.map((a, i) => (
+            <div
+              key={`${a.name}-${i}`}
+              data-testid="chat-composer-attachment-chip"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "4px 8px",
+                background: "var(--color-raised)",
+                border: "1px solid var(--color-border-subtle)",
+                borderRadius: 999,
+                color: "var(--color-text-muted)",
+                fontSize: 12,
+              }}
+            >
+              <FileText size={11} />
+              <span>{a.name}</span>
+              <button
+                type="button"
+                data-testid="chat-composer-attachment-remove"
+                aria-label={`Remove ${a.name}`}
+                onClick={() =>
+                  setAttachments((prev) => prev.filter((_, j) => j !== i))
+                }
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: 16,
+                  height: 16,
+                  background: "transparent",
+                  border: "none",
+                  color: "var(--color-text-muted)",
+                  cursor: "pointer",
+                  padding: 0,
+                }}
+              >
+                <X size={10} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
       <textarea
         data-testid="chat-composer-input"
         placeholder={placeholder}
@@ -67,7 +166,36 @@ export const Composer = ({
           fontSize: 12,
         }}
       >
-        {/* Stub footer — real chips land in Phase 3b */}
+        <button
+          type="button"
+          data-testid="chat-composer-attach"
+          aria-label="Attach file"
+          title="Attach file"
+          onClick={() => fileInputRef.current?.click()}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 24,
+            height: 24,
+            background: "transparent",
+            border: "none",
+            color: "var(--color-text-muted)",
+            cursor: "pointer",
+            padding: 0,
+          }}
+        >
+          <Paperclip size={13} />
+        </button>
+        <input
+          ref={fileInputRef}
+          data-testid="chat-composer-attach-input"
+          type="file"
+          accept="image/*"
+          multiple
+          onChange={handleFileChange}
+          style={{ display: "none" }}
+        />
       </div>
     </div>
   );

--- a/ui/tandem/src/features/chat/ui/Composer.tsx
+++ b/ui/tandem/src/features/chat/ui/Composer.tsx
@@ -4,7 +4,7 @@ import {
   type ChangeEvent,
   type KeyboardEvent,
 } from "react";
-import { FileText, Paperclip, X } from "lucide-react";
+import { Brain, ChevronDown, FileText, Paperclip, Plug, X } from "lucide-react";
 
 export interface ComposerAttachment {
   name: string;
@@ -15,6 +15,11 @@ export interface ComposerAttachment {
 export interface ComposerProps {
   placeholder?: string;
   onSend?: (text: string, attachments: ComposerAttachment[]) => void;
+  disabled?: boolean;
+  contextFolder?: string;
+  mcpCount?: number;
+  tokenUsed?: number;
+  tokenLimit?: number;
 }
 
 function readAsBase64(file: File): Promise<string> {
@@ -34,9 +39,27 @@ function readAsBase64(file: File): Promise<string> {
   });
 }
 
+function formatTokens(used: number, limit: number): string {
+  const fmt = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n));
+  return `${fmt(used)} / ${fmt(limit)}`;
+}
+
+function tokenColor(used: number, limit: number): string {
+  if (limit <= 0) return "var(--color-success, #4ade80)";
+  const ratio = used / limit;
+  if (ratio >= 0.8) return "var(--color-danger, #ef4444)";
+  if (ratio >= 0.6) return "var(--color-warning, #f59e0b)";
+  return "var(--color-success, #4ade80)";
+}
+
 export const Composer = ({
   placeholder = "Ask anything, or paste a file…",
   onSend,
+  disabled = false,
+  contextFolder = "Default",
+  mcpCount = 0,
+  tokenUsed = 0,
+  tokenLimit = 0,
 }: ComposerProps) => {
   const [value, setValue] = useState("");
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
@@ -142,6 +165,7 @@ export const Composer = ({
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={handleKeyDown}
+        disabled={disabled}
         style={{
           width: "100%",
           minHeight: 44,
@@ -153,6 +177,7 @@ export const Composer = ({
           fontFamily: "var(--font-ui)",
           fontSize: 14,
           lineHeight: 1.5,
+          ...(disabled ? { opacity: 0.5, cursor: "not-allowed" } : {}),
         }}
       />
       <div
@@ -171,6 +196,7 @@ export const Composer = ({
           data-testid="chat-composer-attach"
           aria-label="Attach file"
           title="Attach file"
+          disabled={disabled}
           onClick={() => fileInputRef.current?.click()}
           style={{
             display: "inline-flex",
@@ -181,8 +207,10 @@ export const Composer = ({
             background: "transparent",
             border: "none",
             color: "var(--color-text-muted)",
-            cursor: "pointer",
             padding: 0,
+            ...(disabled
+              ? { opacity: 0.5, cursor: "not-allowed" }
+              : { cursor: "pointer" }),
           }}
         >
           <Paperclip size={13} />
@@ -196,6 +224,78 @@ export const Composer = ({
           onChange={handleFileChange}
           style={{ display: "none" }}
         />
+        <div style={{ flex: 1 }} />
+        <div
+          data-testid="chat-composer-context-folder"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+            color: "var(--color-text-muted)",
+          }}
+        >
+          <Brain size={12} />
+          <span>{contextFolder}</span>
+          <ChevronDown size={10} />
+        </div>
+        <div
+          data-testid="chat-composer-token-counter"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
+          <div
+            style={{
+              width: 40,
+              height: 4,
+              borderRadius: 2,
+              background: "var(--color-border-subtle)",
+              overflow: "hidden",
+            }}
+          >
+            <div
+              style={{
+                width: `${tokenLimit > 0 ? Math.min(100, (tokenUsed / tokenLimit) * 100) : 0}%`,
+                height: "100%",
+                borderRadius: 2,
+                background: tokenColor(tokenUsed, tokenLimit),
+              }}
+            />
+          </div>
+          <span style={{ color: tokenColor(tokenUsed, tokenLimit) }}>
+            {formatTokens(tokenUsed, tokenLimit)}
+          </span>
+        </div>
+        <div
+          data-testid="chat-composer-mcp-count"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+            color: "var(--color-text-muted)",
+          }}
+        >
+          <Plug size={12} />
+          <span
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              minWidth: 16,
+              height: 16,
+              borderRadius: 999,
+              background: "var(--color-accent)",
+              color: "#fff",
+              fontSize: 10,
+              fontWeight: 600,
+              padding: "0 4px",
+            }}
+          >
+            {mcpCount}
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/ui/tandem/src/features/chat/ui/EmptyState.tsx
+++ b/ui/tandem/src/features/chat/ui/EmptyState.tsx
@@ -1,10 +1,13 @@
 import { getTimeOfDay } from "@/features/chat/lib/timeOfDay";
 import { DEFAULT_USER_NAME } from "@/features/chat/lib/userIdentity";
-import { Composer } from "@/features/chat/ui/Composer";
+import {
+  Composer,
+  type ComposerAttachment,
+} from "@/features/chat/ui/Composer";
 
 export interface EmptyStateProps {
   name?: string;
-  onSend?: (text: string) => void;
+  onSend?: (text: string, attachments: ComposerAttachment[]) => void;
 }
 
 export const EmptyState = ({

--- a/ui/tandem/src/features/chat/ui/EmptyState.tsx
+++ b/ui/tandem/src/features/chat/ui/EmptyState.tsx
@@ -8,11 +8,13 @@ import {
 export interface EmptyStateProps {
   name?: string;
   onSend?: (text: string, attachments: ComposerAttachment[]) => void;
+  composerDisabled?: boolean;
 }
 
 export const EmptyState = ({
   name = DEFAULT_USER_NAME,
   onSend,
+  composerDisabled = false,
 }: EmptyStateProps) => {
   const tod = getTimeOfDay();
   return (
@@ -41,7 +43,7 @@ export const EmptyState = ({
         <br />
         <em>What are we working on?</em>
       </div>
-      <Composer onSend={onSend} />
+      <Composer onSend={onSend} disabled={composerDisabled} />
     </div>
   );
 };

--- a/ui/tandem/src/features/chat/ui/ProvidersBanner.tsx
+++ b/ui/tandem/src/features/chat/ui/ProvidersBanner.tsx
@@ -1,0 +1,30 @@
+import { AlertTriangle } from "lucide-react";
+
+export const ProvidersBanner = () => (
+  <div
+    data-testid="providers-banner"
+    style={{
+      display: "flex",
+      alignItems: "center",
+      gap: 10,
+      padding: "10px 16px",
+      background: "var(--color-warning-dim, rgba(245, 158, 11, 0.1))",
+      border: "1px solid var(--color-warning, #f59e0b)",
+      borderRadius: 8,
+      margin: "8px 16px 0",
+      color: "var(--color-text)",
+      fontSize: 13,
+      fontFamily: "var(--font-ui)",
+      lineHeight: 1.4,
+    }}
+  >
+    <AlertTriangle
+      size={16}
+      style={{ color: "var(--color-warning, #f59e0b)", flexShrink: 0 }}
+    />
+    <span>
+      No providers configured. Open goose2 to set up an API key, then restart
+      Tandem.
+    </span>
+  </div>
+);

--- a/ui/tandem/src/features/chat/ui/Timeline.tsx
+++ b/ui/tandem/src/features/chat/ui/Timeline.tsx
@@ -1,6 +1,8 @@
 import { Sparkles } from "lucide-react";
 
 import { useChatStore } from "@/features/chat/stores/chatStore";
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { getUserInitials } from "@/features/chat/lib/userIdentity";
 import { getTextContent, type Message } from "@/shared/types/messages";
 import type { ChatState } from "@/shared/types/chat";
@@ -16,6 +18,16 @@ const ASSISTANT_BUSY_STATES: ReadonlySet<ChatState> = new Set([
   "streaming",
 ]);
 
+function usePersonaNameForSession(sessionId: string): string {
+  const personaId = useChatSessionStore(
+    (s) => s.sessions.find((sess) => sess.id === sessionId)?.personaId,
+  );
+  const personaName = useAgentStore((s) =>
+    personaId ? s.personas.find((p) => p.id === personaId)?.displayName : undefined,
+  );
+  return personaName ?? "Tandem";
+}
+
 export const Timeline = ({ sessionId }: TimelineProps) => {
   const messages = useChatStore(
     (s) => s.messagesBySession[sessionId] ?? EMPTY_MESSAGES,
@@ -24,6 +36,7 @@ export const Timeline = ({ sessionId }: TimelineProps) => {
     (s) => s.sessionStateById[sessionId]?.chatState ?? "idle",
   );
   const showTypingIndicator = ASSISTANT_BUSY_STATES.has(chatState);
+  const personaName = usePersonaNameForSession(sessionId);
 
   return (
     <div
@@ -38,7 +51,7 @@ export const Timeline = ({ sessionId }: TimelineProps) => {
       }}
     >
       {messages.map((m) => (
-        <MessageRow key={m.id} message={m} />
+        <MessageRow key={m.id} message={m} personaName={personaName} />
       ))}
       {showTypingIndicator && <TypingIndicator />}
     </div>
@@ -124,7 +137,13 @@ const Avatar = ({ message }: { message: Message }) => {
   );
 };
 
-const MessageRow = ({ message }: { message: Message }) => {
+const MessageRow = ({
+  message,
+  personaName,
+}: {
+  message: Message;
+  personaName: string;
+}) => {
   return (
     <div
       data-testid={`chat-message-${message.role}`}
@@ -136,16 +155,32 @@ const MessageRow = ({ message }: { message: Message }) => {
       }}
     >
       <Avatar message={message} />
-      <div
-        style={{
-          fontFamily: "var(--font-reading)",
-          color: "var(--color-text)",
-          whiteSpace: "pre-wrap",
-          lineHeight: 1.55,
-          paddingTop: 4,
-        }}
-      >
-        {getTextContent(message)}
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        {message.role === "assistant" && (
+          <div
+            data-testid={`chat-message-persona-${message.id}`}
+            style={{
+              fontFamily: "var(--font-ui)",
+              fontSize: 12,
+              fontWeight: 500,
+              color: "var(--color-text)",
+              marginBottom: 2,
+            }}
+          >
+            {personaName}
+          </div>
+        )}
+        <div
+          style={{
+            fontFamily: "var(--font-reading)",
+            color: "var(--color-text)",
+            whiteSpace: "pre-wrap",
+            lineHeight: 1.55,
+            paddingTop: message.role === "assistant" ? 0 : 4,
+          }}
+        >
+          {getTextContent(message)}
+        </div>
       </div>
     </div>
   );

--- a/ui/tandem/src/features/chat/ui/__tests__/Composer.test.tsx
+++ b/ui/tandem/src/features/chat/ui/__tests__/Composer.test.tsx
@@ -19,7 +19,7 @@ describe("Composer", () => {
     await user.keyboard("{Enter}");
 
     expect(onSend).toHaveBeenCalledTimes(1);
-    expect(onSend).toHaveBeenCalledWith("hello world");
+    expect(onSend).toHaveBeenCalledWith("hello world", []);
   });
 
   it("clears the input after submitting", async () => {
@@ -74,5 +74,110 @@ describe("Composer", () => {
 
     expect(onSend).not.toHaveBeenCalled();
     expect(input.value).toBe("line one\nline two");
+  });
+
+  it("renders an attach button and a hidden image-only file input", () => {
+    render(<Composer />);
+
+    const attachButton = screen.getByTestId("chat-composer-attach");
+    expect(attachButton).toBeInTheDocument();
+    expect(attachButton).toHaveAttribute("aria-label", "Attach file");
+
+    const fileInput = screen.getByTestId(
+      "chat-composer-attach-input",
+    ) as HTMLInputElement;
+    expect(fileInput).toBeInTheDocument();
+    expect(fileInput.type).toBe("file");
+    expect(fileInput.accept).toMatch(/^image\//);
+  });
+
+  it("renders an attachment chip after the user picks an image", async () => {
+    const user = userEvent.setup();
+    render(<Composer />);
+    const fileInput = screen.getByTestId(
+      "chat-composer-attach-input",
+    ) as HTMLInputElement;
+
+    const file = new File(["fake-png-bytes"], "screenshot.png", {
+      type: "image/png",
+    });
+    await user.upload(fileInput, file);
+
+    const chip = await screen.findByTestId("chat-composer-attachment-chip");
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveTextContent("screenshot.png");
+  });
+
+  it("calls onSend with text and the attachments array on Enter", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<Composer onSend={onSend} />);
+    const fileInput = screen.getByTestId(
+      "chat-composer-attach-input",
+    ) as HTMLInputElement;
+    const file = new File(["fake-png-bytes"], "diagram.png", {
+      type: "image/png",
+    });
+    await user.upload(fileInput, file);
+    await screen.findByTestId("chat-composer-attachment-chip");
+
+    const input = screen.getByTestId("chat-composer-input");
+    await user.type(input, "look at this");
+    await user.keyboard("{Enter}");
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    const [text, attachments] = onSend.mock.calls[0];
+    expect(text).toBe("look at this");
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]).toMatchObject({
+      name: "diagram.png",
+      mimeType: "image/png",
+    });
+    expect(typeof attachments[0].data).toBe("string");
+    expect(attachments[0].data.length).toBeGreaterThan(0);
+  });
+
+  it("clears attachments after a successful submit", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<Composer onSend={onSend} />);
+    const fileInput = screen.getByTestId(
+      "chat-composer-attach-input",
+    ) as HTMLInputElement;
+    await user.upload(
+      fileInput,
+      new File(["b"], "shot.png", { type: "image/png" }),
+    );
+    await screen.findByTestId("chat-composer-attachment-chip");
+    const input = screen.getByTestId("chat-composer-input");
+    await user.type(input, "go");
+    await user.keyboard("{Enter}");
+
+    expect(
+      screen.queryByTestId("chat-composer-attachment-chip"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("removes an attachment when its remove (×) button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<Composer />);
+    const fileInput = screen.getByTestId(
+      "chat-composer-attach-input",
+    ) as HTMLInputElement;
+
+    const file = new File(["bytes"], "diagram.png", { type: "image/png" });
+    await user.upload(fileInput, file);
+
+    const chip = await screen.findByTestId("chat-composer-attachment-chip");
+    const removeButton = chip.querySelector<HTMLButtonElement>(
+      '[data-testid="chat-composer-attachment-remove"]',
+    );
+    expect(removeButton).not.toBeNull();
+
+    await user.click(removeButton as HTMLButtonElement);
+
+    expect(
+      screen.queryByTestId("chat-composer-attachment-chip"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/tandem/src/features/providers/api/inventory.ts
+++ b/ui/tandem/src/features/providers/api/inventory.ts
@@ -1,0 +1,10 @@
+import type { ProviderInventoryEntryDto } from "@aaif/goose-sdk";
+import { getClient } from "@/shared/api/acpConnection";
+
+export async function getProviderInventory(
+  providerIds: string[] = [],
+): Promise<ProviderInventoryEntryDto[]> {
+  const client = await getClient();
+  const response = await client.goose.GooseProvidersList({ providerIds });
+  return response.entries;
+}


### PR DESCRIPTION
## Summary

Re-implements all of Phase 3a Part 2 (slices 7b-11), which were partially lost from the original `tandem/feat/v1.0-phase-3a-wireup` branch (only slices 7b-8 survived on origin).

- **Slice 7b** — Wire `setNotificationHandler` in `useAppStartup` so ACP session events flow into `chatStore`
- **Slice 8** — File attach button + image attachments in ACP prompt payload
- **Slice 9** — Persona name header on assistant messages (session-level lookup from `agentStore.personas`, fallback "Tandem")
- **Slice 10** — Stub composer footer: context folder chip, token counter with color thresholds, MCP count badge
- **Slice 11** — `ProvidersBanner` when no configured providers; disabled composer; `useAppStartup` loads provider inventory

## Test plan

- [x] 243 tests pass (8 new for slices 9-11)
- [x] 2 pre-existing SDK import failures unchanged
- [x] No new TypeScript errors (only pre-existing `@aaif/goose-sdk` resolution)
- [x] Persona name renders "Tandem" as fallback, real name when agentStore has matching persona
- [x] Banner shows/hides based on `configured: true` in provider inventory
- [x] Composer disabled when no providers configured
- [x] Footer chips (context folder, token counter, MCP count) render in composer

Closes #17 (when Part 3 also merges — see renderers branch)

Made with [Cursor](https://cursor.com)