### PR TITLE
Phase 3b — Composer footer (model picker + indicators) + first-launch UX

### DIFF
--- a/ui/tandem/src/app/__tests__/AppShell.test.tsx
+++ b/ui/tandem/src/app/__tests__/AppShell.test.tsx
@@ -7,12 +7,17 @@ vi.mock("@/shared/api/acpConnection", () => ({
   setNotificationHandler: vi.fn(),
 }));
 
-const { mockAcpCreateSession, mockAcpSendMessage, mockResolvePath } =
-  vi.hoisted(() => ({
-    mockAcpCreateSession: vi.fn(),
-    mockAcpSendMessage: vi.fn(),
-    mockResolvePath: vi.fn(),
-  }));
+const {
+  mockAcpCreateSession,
+  mockAcpSendMessage,
+  mockAcpSetModel,
+  mockResolvePath,
+} = vi.hoisted(() => ({
+  mockAcpCreateSession: vi.fn(),
+  mockAcpSendMessage: vi.fn(),
+  mockAcpSetModel: vi.fn(),
+  mockResolvePath: vi.fn(),
+}));
 
 vi.mock("@/shared/api/acp", async (importActual) => {
   const actual = await importActual<typeof import("@/shared/api/acp")>();
@@ -20,6 +25,7 @@ vi.mock("@/shared/api/acp", async (importActual) => {
     ...actual,
     acpCreateSession: mockAcpCreateSession,
     acpSendMessage: mockAcpSendMessage,
+    acpSetModel: mockAcpSetModel,
   };
 });
 
@@ -86,6 +92,8 @@ describe("AppShell", () => {
     localStorage.clear();
     mockAcpCreateSession.mockReset();
     mockAcpSendMessage.mockReset();
+    mockAcpSetModel.mockReset();
+    mockAcpSetModel.mockResolvedValue(undefined);
     mockResolvePath.mockReset();
     mockResolvePath.mockResolvedValue({
       path: "/home/test/.goose/artifacts",
@@ -913,7 +921,250 @@ describe("AppShell", () => {
     expect(screen.getByTestId("tab-abc")).toBeInTheDocument();
     await user.click(screen.getByTestId("tab-close-abc"));
     expect(screen.queryByTestId("tab-abc")).not.toBeInTheDocument();
-    // Session still in history
     expect(screen.getByTestId("session-row-abc")).toBeInTheDocument();
+  });
+
+  describe("model picker (Phase 3b)", () => {
+    it("renders the model picker trigger in the composer footer", () => {
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      seedTabs([draftId], draftId);
+
+      render(<AppShell />);
+
+      expect(screen.getByTestId("model-picker-trigger")).toBeInTheDocument();
+    });
+
+    it("shows 'Select model' when no model is set on the session", () => {
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      seedTabs([draftId], draftId);
+
+      render(<AppShell />);
+
+      expect(screen.getByTestId("model-picker-trigger")).toHaveTextContent(
+        "Select model",
+      );
+    });
+
+    it("reflects the active session's model name", () => {
+      seedTabs(["sess-1"], "sess-1");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-1",
+            title: "Chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+            modelId: "gpt-4o",
+            modelName: "GPT-4o",
+          },
+        ],
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-1": [
+            {
+              id: "u1",
+              role: "user",
+              created: 1,
+              content: [{ type: "text", text: "hi" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+      });
+
+      render(<AppShell />);
+
+      expect(screen.getByTestId("model-picker-trigger")).toHaveTextContent(
+        "GPT-4o",
+      );
+    });
+
+    it("opens a dropdown with available models on click", async () => {
+      const user = userEvent.setup();
+      const draftId = `${DRAFT_TAB_PREFIX}abc`;
+      seedTabs([draftId], draftId);
+      useProviderInventoryStore.getState().setEntries([
+        {
+          providerId: "openai",
+          providerName: "OpenAI",
+          configured: true,
+          models: [
+            { id: "gpt-4o", name: "GPT-4o" },
+            { id: "gpt-4o-mini", name: "GPT-4o Mini" },
+          ],
+        } as never,
+      ]);
+
+      render(<AppShell />);
+
+      await user.click(screen.getByTestId("model-picker-trigger"));
+      expect(screen.getByTestId("model-picker-dropdown")).toBeInTheDocument();
+      expect(screen.getByTestId("model-option-gpt-4o")).toHaveTextContent(
+        "GPT-4o",
+      );
+      expect(screen.getByTestId("model-option-gpt-4o-mini")).toHaveTextContent(
+        "GPT-4o Mini",
+      );
+    });
+
+    it("selecting a model updates the session store", async () => {
+      const user = userEvent.setup();
+      seedTabs(["sess-1"], "sess-1");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-1",
+            title: "Chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+          },
+        ],
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-1": [
+            {
+              id: "u1",
+              role: "user",
+              created: 1,
+              content: [{ type: "text", text: "hi" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+      });
+      useProviderInventoryStore.getState().setEntries([
+        {
+          providerId: "anthropic",
+          providerName: "Anthropic",
+          configured: true,
+          models: [
+            { id: "claude-4-opus", name: "Claude Opus 4" },
+          ],
+        } as never,
+      ]);
+
+      render(<AppShell />);
+
+      await user.click(screen.getByTestId("model-picker-trigger"));
+      await user.click(screen.getByTestId("model-option-claude-4-opus"));
+
+      const session = useChatSessionStore
+        .getState()
+        .sessions.find((s) => s.id === "sess-1");
+      expect(session?.modelId).toBe("claude-4-opus");
+      expect(session?.modelName).toBe("Claude Opus 4");
+    });
+
+    it("switching tabs shows the correct session's model", () => {
+      seedTabs(["sess-a", "sess-b"], "sess-a");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-a",
+            title: "Chat A",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+            modelId: "gpt-4o",
+            modelName: "GPT-4o",
+          },
+          {
+            id: "sess-b",
+            title: "Chat B",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+            modelId: "claude-4-opus",
+            modelName: "Claude Opus 4",
+          },
+        ],
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-a": [
+            {
+              id: "u1",
+              role: "user",
+              created: 1,
+              content: [{ type: "text", text: "hi" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+          "sess-b": [
+            {
+              id: "u2",
+              role: "user",
+              created: 2,
+              content: [{ type: "text", text: "hello" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+      });
+
+      render(<AppShell />);
+
+      expect(screen.getByTestId("model-picker-trigger")).toHaveTextContent(
+        "GPT-4o",
+      );
+
+      act(() => {
+        useTabsStore.setState({ activeId: "sess-b" });
+      });
+
+      expect(screen.getByTestId("model-picker-trigger")).toHaveTextContent(
+        "Claude Opus 4",
+      );
+    });
+
+    it("status bar model name updates when the active session model changes", () => {
+      seedTabs(["sess-1"], "sess-1");
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            id: "sess-1",
+            title: "Chat",
+            createdAt: "",
+            updatedAt: "",
+            messageCount: 1,
+            modelName: "GPT-4o",
+          },
+        ],
+        activeSessionId: "sess-1",
+      });
+      useChatStore.setState({
+        messagesBySession: {
+          "sess-1": [
+            {
+              id: "u1",
+              role: "user",
+              created: 1,
+              content: [{ type: "text", text: "hi" }],
+              metadata: { userVisible: true, agentVisible: true },
+            },
+          ],
+        },
+      });
+
+      render(<AppShell />);
+
+      expect(screen.getByTestId("status-item-model")).toHaveTextContent(
+        "GPT-4o",
+      );
+
+      act(() => {
+        useChatSessionStore.getState().updateSession("sess-1", {
+          modelName: "Claude Opus 4",
+        });
+      });
+
+      expect(screen.getByTestId("status-item-model")).toHaveTextContent(
+        "Claude Opus 4",
+      );
+    });
   });
 });

--- a/ui/tandem/src/features/chat/ui/ChatPane.tsx
+++ b/ui/tandem/src/features/chat/ui/ChatPane.tsx
@@ -1,7 +1,12 @@
+import { useCallback } from "react";
+
+import { acpSetModel } from "@/shared/api/acp";
 import { useChat } from "@/features/chat/hooks/useChat";
 import { useChatStore } from "@/features/chat/stores/chatStore";
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import { Composer } from "@/features/chat/ui/Composer";
 import { EmptyState } from "@/features/chat/ui/EmptyState";
+import type { ModelOption } from "@/features/chat/ui/ModelPicker";
 import { ProvidersBanner } from "@/features/chat/ui/ProvidersBanner";
 import { Timeline } from "@/features/chat/ui/Timeline";
 import { useProviderInventoryStore } from "@/features/providers/stores/providerInventoryStore";
@@ -20,6 +25,31 @@ export const ChatPane = () => {
     return false;
   });
 
+  const activeSession = useChatSessionStore((s) =>
+    activeTabId ? s.sessions.find((sess) => sess.id === activeTabId) : undefined,
+  );
+
+  const handleModelSelect = useCallback(
+    (option: ModelOption) => {
+      if (!activeTabId) return;
+      useChatSessionStore.getState().updateSession(activeTabId, {
+        modelId: option.modelId,
+        modelName: option.modelName,
+        providerId: option.providerId,
+      });
+      void acpSetModel(activeTabId, option.modelId).catch((err: unknown) =>
+        console.error("Failed to set model:", err),
+      );
+    },
+    [activeTabId],
+  );
+
+  const modelPickerProps = {
+    selectedModelId: activeSession?.modelId,
+    selectedModelName: activeSession?.modelName,
+    onModelSelect: handleModelSelect,
+  };
+
   return (
     <div
       style={{
@@ -34,6 +64,7 @@ export const ChatPane = () => {
         <EmptyState
           onSend={send}
           composerDisabled={!hasConfiguredProvider}
+          {...modelPickerProps}
         />
       ) : (
         <div
@@ -60,6 +91,7 @@ export const ChatPane = () => {
               tokenUsed={tokenState?.accumulatedTotal ?? 0}
               tokenLimit={tokenState?.contextLimit ?? 0}
               disabled={!hasConfiguredProvider}
+              {...modelPickerProps}
             />
           </div>
         </div>

--- a/ui/tandem/src/features/chat/ui/Composer.tsx
+++ b/ui/tandem/src/features/chat/ui/Composer.tsx
@@ -13,6 +13,8 @@ import {
   X,
 } from "lucide-react";
 
+import { ModelPicker, type ModelOption } from "@/features/chat/ui/ModelPicker";
+
 export interface ComposerAttachment {
   name: string;
   mimeType: string;
@@ -27,6 +29,9 @@ export interface ComposerProps {
   tokenUsed?: number;
   tokenLimit?: number;
   disabled?: boolean;
+  selectedModelId?: string;
+  selectedModelName?: string;
+  onModelSelect?: (option: ModelOption) => void;
 }
 
 function formatTokenCount(used: number, limit: number): string {
@@ -77,6 +82,9 @@ export const Composer = ({
   tokenUsed = 0,
   tokenLimit = 0,
   disabled = false,
+  selectedModelId,
+  selectedModelName,
+  onModelSelect,
 }: ComposerProps) => {
   const tokenLabel = formatTokenCount(tokenUsed, tokenLimit);
   const tokenPct = tokenLimit > 0 ? Math.min(100, (tokenUsed / tokenLimit) * 100) : 0;
@@ -215,6 +223,12 @@ export const Composer = ({
           fontSize: 12,
         }}
       >
+        <ModelPicker
+          selectedModelId={selectedModelId}
+          selectedModelName={selectedModelName}
+          onSelect={onModelSelect ?? (() => {})}
+          disabled={disabled}
+        />
         <div data-testid="chat-composer-context-folder" style={chipStyle}>
           <Brain size={13} />
           <span>{contextFolder}</span>

--- a/ui/tandem/src/features/chat/ui/EmptyState.tsx
+++ b/ui/tandem/src/features/chat/ui/EmptyState.tsx
@@ -4,17 +4,24 @@ import {
   Composer,
   type ComposerAttachment,
 } from "@/features/chat/ui/Composer";
+import type { ModelOption } from "@/features/chat/ui/ModelPicker";
 
 export interface EmptyStateProps {
   name?: string;
   onSend?: (text: string, attachments: ComposerAttachment[]) => void;
   composerDisabled?: boolean;
+  selectedModelId?: string;
+  selectedModelName?: string;
+  onModelSelect?: (option: ModelOption) => void;
 }
 
 export const EmptyState = ({
   name = DEFAULT_USER_NAME,
   onSend,
   composerDisabled = false,
+  selectedModelId,
+  selectedModelName,
+  onModelSelect,
 }: EmptyStateProps) => {
   const tod = getTimeOfDay();
   return (
@@ -43,7 +50,13 @@ export const EmptyState = ({
         <br />
         <em>What are we working on?</em>
       </div>
-      <Composer onSend={onSend} disabled={composerDisabled} />
+      <Composer
+        onSend={onSend}
+        disabled={composerDisabled}
+        selectedModelId={selectedModelId}
+        selectedModelName={selectedModelName}
+        onModelSelect={onModelSelect}
+      />
     </div>
   );
 };

--- a/ui/tandem/src/features/chat/ui/ModelPicker.tsx
+++ b/ui/tandem/src/features/chat/ui/ModelPicker.tsx
@@ -1,0 +1,157 @@
+import { useState, useRef, useEffect, useMemo } from "react";
+import { ChevronDown, Bot } from "lucide-react";
+
+import { useProviderInventoryStore } from "@/features/providers/stores/providerInventoryStore";
+
+export interface ModelOption {
+  providerId: string;
+  providerName: string;
+  modelId: string;
+  modelName: string;
+}
+
+export interface ModelPickerProps {
+  selectedModelId?: string;
+  selectedModelName?: string;
+  onSelect: (option: ModelOption) => void;
+  disabled?: boolean;
+}
+
+function useAvailableModels(): ModelOption[] {
+  const entries = useProviderInventoryStore((s) => s.entries);
+  return useMemo(() => {
+    const options: ModelOption[] = [];
+    for (const entry of entries.values()) {
+      if (!entry.configured) continue;
+      for (const model of entry.models ?? []) {
+        options.push({
+          providerId: entry.providerId,
+          providerName: (entry as Record<string, unknown>).providerName as string ?? entry.providerId,
+          modelId: model.id,
+          modelName: model.name ?? model.id,
+        });
+      }
+    }
+    return options;
+  }, [entries]);
+}
+
+export const ModelPicker = ({
+  selectedModelId,
+  selectedModelName,
+  onSelect,
+  disabled = false,
+}: ModelPickerProps) => {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const models = useAvailableModels();
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  const displayName = selectedModelName || selectedModelId || "Select model";
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="model-picker"
+      style={{ position: "relative", display: "inline-flex" }}
+    >
+      <button
+        type="button"
+        data-testid="model-picker-trigger"
+        onClick={() => !disabled && setOpen(!open)}
+        disabled={disabled}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+          height: 26,
+          padding: "0 8px",
+          borderRadius: 6,
+          background: "transparent",
+          border: "none",
+          color: "var(--color-text-muted)",
+          fontSize: 12,
+          fontFamily: "var(--font-ui)",
+          whiteSpace: "nowrap",
+          cursor: disabled ? "not-allowed" : "pointer",
+          opacity: disabled ? 0.5 : 1,
+        }}
+      >
+        <Bot size={13} />
+        <span>{displayName}</span>
+        <ChevronDown size={11} style={{ opacity: 0.6 }} />
+      </button>
+
+      {open && models.length > 0 && (
+        <div
+          data-testid="model-picker-dropdown"
+          style={{
+            position: "absolute",
+            bottom: "100%",
+            left: 0,
+            marginBottom: 4,
+            minWidth: 240,
+            maxHeight: 300,
+            overflowY: "auto",
+            background: "var(--color-surface)",
+            border: "1px solid var(--color-border)",
+            borderRadius: 8,
+            boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+            zIndex: 100,
+            padding: 4,
+          }}
+        >
+          {models.map((m) => {
+            const isActive = m.modelId === selectedModelId;
+            return (
+              <button
+                key={`${m.providerId}-${m.modelId}`}
+                type="button"
+                data-testid={`model-option-${m.modelId}`}
+                onClick={() => {
+                  onSelect(m);
+                  setOpen(false);
+                }}
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 2,
+                  width: "100%",
+                  padding: "6px 10px",
+                  borderRadius: 6,
+                  background: isActive ? "var(--color-raised)" : "transparent",
+                  border: "none",
+                  cursor: "pointer",
+                  textAlign: "left",
+                  color: "var(--color-text)",
+                  fontSize: 12,
+                  fontFamily: "var(--font-ui)",
+                }}
+              >
+                <span style={{ fontWeight: 500 }}>{m.modelName}</span>
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: "var(--color-text-muted)",
+                  }}
+                >
+                  {m.providerName}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/ui/tandem/src/features/connection/ui/ConnectionIndicator.tsx
+++ b/ui/tandem/src/features/connection/ui/ConnectionIndicator.tsx
@@ -13,7 +13,7 @@ const COLOR: Record<ConnectionStatus, string> = {
 const TITLE: Record<ConnectionStatus, string> = {
   connected: "Connected to backend",
   connecting: "Connecting to backend…",
-  failed: "Backend unreachable",
+  failed: "Backend unreachable — check that goose serve is running and restart Tandem",
 };
 
 export const ConnectionIndicator = ({ status }: ConnectionIndicatorProps) => (

--- a/ui/tandem/src/features/connection/ui/__tests__/ConnectionIndicator.test.tsx
+++ b/ui/tandem/src/features/connection/ui/__tests__/ConnectionIndicator.test.tsx
@@ -20,7 +20,7 @@ describe("ConnectionIndicator", () => {
     render(<ConnectionIndicator status="failed" />);
     const dot = screen.getByTestId("connection-dot");
     expect(dot).toHaveStyle({ background: "var(--color-danger)" });
-    expect(dot).toHaveAttribute("title", "Backend unreachable");
+    expect(dot).toHaveAttribute("title", "Backend unreachable — check that goose serve is running and restart Tandem");
   });
 
   it("explains the live state via title for screen readers when connected", () => {


### PR DESCRIPTION
## Summary

Final v1.0 phase. Implements the interactive model picker and remaining launch UX items.

- **Model picker dropdown** — lists available providers/models from `providerInventoryStore`, selecting calls `acpSetModel(sessionId, modelId)`, updates `chatSessionStore`, persists per-session, StatusBar model name syncs
- **Connection tooltip** — StatusBar dot explains backend unreachable state with actionable guidance
- **Read-only indicators** — context folder, MCP count, token counter (already from Phase 3a, retained and working)
- **ProvidersBanner** — persists when no providers configured (already from Phase 3a, retained)

## Test plan

- [x] 258 tests pass (7 new model picker tests)
- [x] 2 pre-existing SDK failures unchanged
- [x] No new TypeScript errors
- [x] Model picker trigger shows active session's model name
- [x] Dropdown lists models from configured providers only
- [x] Selecting a model updates session store (modelId + modelName)
- [x] Tab switching preserves each session's model choice
- [x] StatusBar model name updates reactively
- [x] Connection dot tooltip shows actionable guidance for failed state

Closes #18

After merge: tag `tandem/main` as `tandem/v1.0`

Made with [Cursor](https://cursor.com)