### PR TITLE
feat(tandem): match Logo A spec, add wordmark in expanded sidebar

### DIFF
--- a/ui/tandem/src/features/sidebar/ui/Sidebar.tsx
+++ b/ui/tandem/src/features/sidebar/ui/Sidebar.tsx
@@ -317,7 +317,14 @@ export function Sidebar({
               collapsed ? "justify-center" : "justify-between",
             )}
           >
-            <TandemIcon className="text-foreground" />
+            <div className="flex items-center gap-1">
+              <TandemIcon className="text-foreground" />
+              {!collapsed && (
+                <span className="text-base font-semibold leading-none tracking-tight whitespace-nowrap text-[#5a5b62] dark:text-[#CECECE]">
+                  Tandem
+                </span>
+              )}
+            </div>
             {!collapsed && (
               <Button
                 type="button"

--- a/ui/tandem/src/shared/ui/icons/TandemIcon.tsx
+++ b/ui/tandem/src/shared/ui/icons/TandemIcon.tsx
@@ -10,10 +10,10 @@ export function TandemIcon({ className = "" }: { className?: string }) {
       aria-hidden="true"
     >
       <title>Tandem</title>
-      <circle cx="14.5" cy="10" r="8" className="fill-[#CECECE] dark:fill-[#6E6E6E]" />
-      <circle cx="16.5" cy="8" r="2" fill="#9E9E9E" />
-      <circle cx="9.5" cy="14" r="8" className="fill-[#CECECE] dark:fill-[#6E6E6E]" />
-      <circle cx="7.5" cy="12" r="2" fill="#F37021" />
+      <circle cx="15.26" cy="11.98" r="7.55" className="fill-[#5a5b62] dark:fill-[#CECECE]" />
+      <circle cx="15.26" cy="11.98" r="2.95" className="fill-[#2a2b31] dark:fill-[#9E9E9E]" />
+      <circle cx="8.77" cy="11.98" r="7.55" className="fill-[#3a3b40] dark:fill-[#6E6E6E]" />
+      <circle cx="8.77" cy="11.98" r="2.95" fill="#F37021" />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- Fix TandemIcon geometry to match the Logo A design spec (horizontal disc pairing at cy=11.98, r=7.55 outers, r=2.95 inner dots centered on each disc, literal hex fills per the light/dark UI guidance).
- Add the **Tandem** wordmark next to the icon in the expanded sidebar header. Collapsed state still shows only the icon.

## Design source
Spec from Claude Design — `analysis/Tandem Logo A.html` (status quo).

## Test plan
- [x] Open the app, verify the sidebar header at expanded width renders the mark + "Tandem" wordmark on one line.
- [x] Collapse the sidebar; verify only the mark renders, centered.
- [x] Toggle dark mode; verify the wordmark switches color (back-disc grey: #5a5b62 light → #CECECE dark).
- [x] Check the mark at the other call sites (`GooseLogo` 32 px / 64 px) — proportions should hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
