### PR TITLE
refactor(tandem): trim density token and picker

### DIFF
--- a/ui/tandem/AGENTS.md
+++ b/ui/tandem/AGENTS.md
@@ -94,13 +94,12 @@ Not every feature needs every subdirectory. Use only what the feature requires:
 
 ## Theming System
 
-ThemeProvider manages three axes:
+ThemeProvider manages two axes:
 
 | Axis         | Values                          | Persistence     | Mechanism                                    |
 |--------------|---------------------------------|-----------------|----------------------------------------------|
 | Theme mode   | `light`, `dark`, `system`       | localStorage    | `.dark` class on `<html>`                    |
 | Accent color | Any hex value                   | localStorage    | `--color-accent` CSS variable                |
-| Density      | `compact`, `comfortable`, `spacious` | localStorage | `--density-spacing` CSS variable (0.75/1/1.25) |
 
 - CSS variables are defined in `globals.css` with light/dark variants.
 - Tailwind config maps CSS variables to semantic color names.

--- a/ui/tandem/src/features/settings/ui/AppearanceSettings.tsx
+++ b/ui/tandem/src/features/settings/ui/AppearanceSettings.tsx
@@ -22,12 +22,6 @@ const ACCENT_COLORS = [
   { name: "indigo", value: "#6366f1" },
 ];
 
-const DENSITY_OPTIONS = [
-  { value: "compact" },
-  { value: "comfortable" },
-  { value: "spacious" },
-] as const;
-
 function SettingRow({
   label,
   description,
@@ -52,8 +46,7 @@ function SettingRow({
 
 export function AppearanceSettings() {
   const { t } = useTranslation("settings");
-  const { theme, setTheme, accentColor, setAccentColor, density, setDensity } =
-    useTheme();
+  const { theme, setTheme, accentColor, setAccentColor } = useTheme();
 
   return (
     <div>
@@ -115,30 +108,6 @@ export function AppearanceSettings() {
             </button>
           ))}
         </div>
-      </SettingRow>
-
-      <Separator className="my-4" />
-
-      <SettingRow
-        label={t("appearance.density.label")}
-        description={t("appearance.density.description")}
-      >
-        <ToggleGroup
-          type="single"
-          value={density}
-          onValueChange={(v) => v && setDensity(v as typeof density)}
-          className="gap-1 rounded-lg bg-muted p-1"
-        >
-          {DENSITY_OPTIONS.map((option) => (
-            <ToggleGroupItem
-              key={option.value}
-              value={option.value}
-              className="rounded-md px-3 py-1.5 text-sm data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm"
-            >
-              {t(`appearance.density.options.${option.value}`)}
-            </ToggleGroupItem>
-          ))}
-        </ToggleGroup>
       </SettingRow>
     </div>
   );

--- a/ui/tandem/src/shared/i18n/locales/en/settings.json
+++ b/ui/tandem/src/shared/i18n/locales/en/settings.json
@@ -18,15 +18,6 @@
       "description": "Choose your accent color",
       "label": "Accent Color"
     },
-    "density": {
-      "description": "Adjust the spacing of UI elements",
-      "label": "Interface Density",
-      "options": {
-        "comfortable": "Comfortable",
-        "compact": "Compact",
-        "spacious": "Spacious"
-      }
-    },
     "description": "Customize the look and feel of Goose",
     "theme": {
       "description": "Choose your preferred color scheme",

--- a/ui/tandem/src/shared/i18n/locales/es/settings.json
+++ b/ui/tandem/src/shared/i18n/locales/es/settings.json
@@ -18,15 +18,6 @@
       "description": "Elige tu color de acento",
       "label": "Color de acento"
     },
-    "density": {
-      "description": "Ajusta el espaciado de los elementos de la interfaz",
-      "label": "Densidad de la interfaz",
-      "options": {
-        "comfortable": "Cómoda",
-        "compact": "Compacta",
-        "spacious": "Espaciosa"
-      }
-    },
     "description": "Personaliza el aspecto de Goose",
     "theme": {
       "description": "Elige tu esquema de color preferido",

--- a/ui/tandem/src/shared/styles/globals.css
+++ b/ui/tandem/src/shared/styles/globals.css
@@ -240,10 +240,9 @@
   --duration-normal: 0.2s;
   --duration-slow: 0.4s;
 
-  /* tandem custom — brand accent + density */
+  /* tandem custom — brand accent */
   --color-brand: #8b7cff;
   --color-brand-foreground: #16171b;
-  --density-spacing: 1;
 }
 
 .dark {
@@ -788,22 +787,6 @@ body,
 /* ═══════════════════════════════════════════════════════════
    tandem custom utilities
    ═══════════════════════════════════════════════════════════ */
-
-/* Density-aware spacing utilities */
-.gap-density {
-  gap: calc(0.5rem * var(--density-spacing));
-}
-.p-density {
-  padding: calc(0.5rem * var(--density-spacing));
-}
-.py-density {
-  padding-top: calc(0.5rem * var(--density-spacing));
-  padding-bottom: calc(0.5rem * var(--density-spacing));
-}
-.px-density {
-  padding-left: calc(0.5rem * var(--density-spacing));
-  padding-right: calc(0.5rem * var(--density-spacing));
-}
 
 /* Page-transition animation */
 @keyframes page-fade-in {

--- a/ui/tandem/src/shared/theme/ThemeProvider.test.tsx
+++ b/ui/tandem/src/shared/theme/ThemeProvider.test.tsx
@@ -4,12 +4,11 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ThemeProvider, useTheme } from "./ThemeProvider";
 
 function ThemeConsumer() {
-  const { theme, setTheme, accentColor, density } = useTheme();
+  const { theme, setTheme, accentColor } = useTheme();
   return (
     <div>
       <span data-testid="theme">{theme}</span>
       <span data-testid="accent">{accentColor}</span>
-      <span data-testid="density">{density}</span>
       <button type="button" onClick={() => setTheme("dark")}>
         Set Dark
       </button>
@@ -68,31 +67,20 @@ describe("ThemeProvider", () => {
     expect(screen.getByTestId("accent")).toHaveTextContent("#8b7cff");
   });
 
-  it("provides default density", () => {
-    render(
-      <ThemeProvider>
-        <ThemeConsumer />
-      </ThemeProvider>,
-    );
-    expect(screen.getByTestId("density")).toHaveTextContent("comfortable");
-  });
-
   describe("localStorage migration", () => {
     it("migrates goose-* keys to tandem-* on import", async () => {
       localStorage.setItem("goose-theme", "dark");
       localStorage.setItem("goose-accent-color", "#ef4444");
-      localStorage.setItem("goose-density", "compact");
 
       vi.resetModules();
       const mod = await import("./ThemeProvider");
 
       function Consumer() {
-        const { theme, accentColor, density } = mod.useTheme();
+        const { theme, accentColor } = mod.useTheme();
         return (
           <div>
             <span data-testid="m-theme">{theme}</span>
             <span data-testid="m-accent">{accentColor}</span>
-            <span data-testid="m-density">{density}</span>
           </div>
         );
       }
@@ -105,14 +93,11 @@ describe("ThemeProvider", () => {
 
       expect(screen.getByTestId("m-theme")).toHaveTextContent("dark");
       expect(screen.getByTestId("m-accent")).toHaveTextContent("#ef4444");
-      expect(screen.getByTestId("m-density")).toHaveTextContent("compact");
 
       expect(localStorage.getItem("tandem-theme")).toBe("dark");
       expect(localStorage.getItem("tandem-accent-color")).toBe("#ef4444");
-      expect(localStorage.getItem("tandem-density")).toBe("compact");
       expect(localStorage.getItem("goose-theme")).toBeNull();
       expect(localStorage.getItem("goose-accent-color")).toBeNull();
-      expect(localStorage.getItem("goose-density")).toBeNull();
     });
 
     it("does not overwrite existing tandem-* keys during migration", async () => {

--- a/ui/tandem/src/shared/theme/ThemeProvider.tsx
+++ b/ui/tandem/src/shared/theme/ThemeProvider.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 
 type ThemePreference = "light" | "dark" | "system";
 type ResolvedTheme = "light" | "dark";
-type Density = "compact" | "comfortable" | "spacious";
 
 type ThemeProviderProps = {
   children: React.ReactNode;
@@ -15,16 +14,14 @@ type ThemeProviderState = {
   setTheme: (theme: ThemePreference) => void;
   accentColor: string;
   setAccentColor: (color: string) => void;
-  density: Density;
-  setDensity: (d: Density) => void;
 };
 
 const ThemeProviderContext = React.createContext<
   ThemeProviderState | undefined
 >(undefined);
 
-const LEGACY_KEYS = ["goose-theme", "goose-accent-color", "goose-density"];
-const NEW_KEYS = ["tandem-theme", "tandem-accent-color", "tandem-density"];
+const LEGACY_KEYS = ["goose-theme", "goose-accent-color"];
+const NEW_KEYS = ["tandem-theme", "tandem-accent-color"];
 
 function migrateLocalStorageKeys() {
   for (let i = 0; i < LEGACY_KEYS.length; i++) {
@@ -79,11 +76,6 @@ export function ThemeProvider({
     return localStorage.getItem("tandem-accent-color") ?? "#8b7cff";
   });
 
-  const [density, setDensityState] = React.useState<Density>(() => {
-    const stored = localStorage.getItem("tandem-density") as Density | null;
-    return stored ?? "comfortable";
-  });
-
   const setTheme = React.useCallback((newTheme: ThemePreference) => {
     localStorage.setItem("tandem-theme", newTheme);
     setThemeState(newTheme);
@@ -92,11 +84,6 @@ export function ThemeProvider({
   const setAccentColor = React.useCallback((color: string) => {
     localStorage.setItem("tandem-accent-color", color);
     setAccentColorState(color);
-  }, []);
-
-  const setDensity = React.useCallback((d: Density) => {
-    localStorage.setItem("tandem-density", d);
-    setDensityState(d);
   }, []);
 
   React.useEffect(() => {
@@ -129,14 +116,7 @@ export function ThemeProvider({
       "--color-brand-foreground",
       getContrastColor(accentColor),
     );
-
-    const spacingScale: Record<Density, string> = {
-      compact: "0.75",
-      comfortable: "1",
-      spacious: "1.25",
-    };
-    root.style.setProperty("--density-spacing", spacingScale[density]);
-  }, [accentColor, density]);
+  }, [accentColor]);
 
   const value = React.useMemo(
     () => ({
@@ -145,18 +125,8 @@ export function ThemeProvider({
       setTheme,
       accentColor,
       setAccentColor,
-      density,
-      setDensity,
     }),
-    [
-      theme,
-      resolvedTheme,
-      setTheme,
-      accentColor,
-      setAccentColor,
-      density,
-      setDensity,
-    ],
+    [theme, resolvedTheme, setTheme, accentColor, setAccentColor],
   );
 
   return (


### PR DESCRIPTION
Closes #46.

## Summary

- Remove the `--density-spacing` token, the four density-aware utility classes, the `density` / `setDensity` state on `ThemeProvider`, the Settings → Appearance density picker, its en/es i18n keys, and the AGENTS.md table row.
- The density utilities had no consumers outside `ThemeProvider.tsx` and `globals.css` themselves, so this is pure dead-code removal — nothing visible changes for users with default settings.
- Stale `tandem-density` / `goose-density` localStorage entries are left as harmless residue rather than adding cleanup code for them.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` 427/427 passing
- [x] Visual: Settings → Appearance now shows only Theme + Accent rows; no density block
- [ ] Lint failures observed (`ArtifactViewer.tsx`, `useChat.ts`, `dictation.test.ts`, `sdk/index.ts`) are pre-existing on `tandem/v2` and unrelated to this PR — verified by stashing the diff and re-running

🤖 Generated with [Claude Code](https://claude.com/claude-code)