### PR TITLE
feat(tandem): bug report modal with redacted bundle, telemetry, and toast UX

### DIFF
--- a/ui/tandem/src-tauri/Cargo.lock
+++ b/ui/tandem/src-tauri/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1288,12 +1288,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1306,6 +1315,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1749,6 +1764,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +1934,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1908,6 +1943,37 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1928,9 +1994,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2558,6 +2626,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2927,6 +3012,49 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3625,6 +3753,46 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3679,6 +3847,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3756,6 +3938,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3774,6 +3989,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4034,6 +4258,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4412,6 +4648,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4438,6 +4695,7 @@ dependencies = [
  "log",
  "mime_guess",
  "regex",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4547,7 +4805,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5043,6 +5301,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5359,6 +5637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5418,6 +5702,12 @@ name = "value-bag"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -5851,6 +6141,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/ui/tandem/src-tauri/Cargo.lock
+++ b/ui/tandem/src-tauri/Cargo.lock
@@ -271,6 +271,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +475,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +577,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -635,6 +663,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
@@ -2215,6 +2249,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,10 +3010,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -4370,6 +4437,7 @@ dependencies = [
  "keyring",
  "log",
  "mime_guess",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4384,6 +4452,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "uuid",
+ "zip",
 ]
 
 [[package]]
@@ -6585,10 +6654,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zvariant"

--- a/ui/tandem/src-tauri/Cargo.toml
+++ b/ui/tandem/src-tauri/Cargo.toml
@@ -37,6 +37,8 @@ ignore = "0.4.25"
 base64 = "0.22"
 mime_guess = "2"
 tauri-plugin-shell = "2"
+zip = "0.6"
+regex = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "3", features = ["apple-native"] }

--- a/ui/tandem/src-tauri/Cargo.toml
+++ b/ui/tandem/src-tauri/Cargo.toml
@@ -39,6 +39,7 @@ mime_guess = "2"
 tauri-plugin-shell = "2"
 zip = "0.6"
 regex = "1"
+reqwest = { version = "0.12", features = ["json"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "3", features = ["apple-native"] }

--- a/ui/tandem/src-tauri/src/commands/bug_report.rs
+++ b/ui/tandem/src-tauri/src/commands/bug_report.rs
@@ -225,13 +225,18 @@ fn resolve_output_dir() -> PathBuf {
     std::env::temp_dir()
 }
 
-fn build_manifest(recent_errors: &str) -> String {
+fn build_manifest(recent_errors: &str, session_id: Option<&str>) -> String {
     let os = std::env::consts::OS;
     let arch = std::env::consts::ARCH;
     let app_version = env!("CARGO_PKG_VERSION");
 
+    let session_line = match session_id {
+        Some(id) => format!("- Session: {id}"),
+        None => "- Session: (none)".to_string(),
+    };
+
     let errors_section = if recent_errors == "_No recent errors._" {
-        format!("_No recent errors._")
+        "_No recent errors._".to_string()
     } else {
         format!("<details>\n<summary>Last errors/warnings</summary>\n\n```\n{recent_errors}\n```\n</details>")
     };
@@ -241,7 +246,7 @@ fn build_manifest(recent_errors: &str) -> String {
          - App version: {app_version}\n\
          - OS: {os}\n\
          - Arch: {arch}\n\
-         - Session: (none)\n\n\
+         {session_line}\n\n\
          ## Recent errors\n\n\
          {errors_section}\n\n\
          ## Diagnostics\n\n\
@@ -265,6 +270,8 @@ fn add_file_to_zip<W: Write + std::io::Seek>(
 pub fn bundle_bug_report_impl(
     screenshots: Vec<String>,
     output_dir: Option<PathBuf>,
+    session_id: Option<String>,
+    session_json: Option<String>,
 ) -> Result<BugReportResult, String> {
     let secret_patterns = build_secret_patterns();
     let state_dir = resolve_state_dir();
@@ -337,6 +344,12 @@ pub fn bundle_bug_report_impl(
         }
     }
 
+    // Session export (scrubbed)
+    if let Some(ref json) = session_json {
+        let scrubbed = scrub_text(json, &secret_patterns);
+        add_file_to_zip(&mut zip, "session.json", scrubbed.as_bytes())?;
+    }
+
     // Screenshots (base64 -> PNG)
     for (i, b64) in screenshots.iter().enumerate() {
         match base64::engine::general_purpose::STANDARD.decode(b64) {
@@ -353,7 +366,7 @@ pub fn bundle_bug_report_impl(
     zip.finish()
         .map_err(|e| format!("Failed to finalize ZIP: {e}"))?;
 
-    let manifest = build_manifest(&recent_errors);
+    let manifest = build_manifest(&recent_errors, session_id.as_deref());
 
     Ok(BugReportResult {
         zip_path: zip_path.to_string_lossy().into_owned(),
@@ -361,11 +374,46 @@ pub fn bundle_bug_report_impl(
     })
 }
 
+async fn fetch_session_export(port: u16, session_id: &str) -> Option<String> {
+    let url = format!("http://127.0.0.1:{port}/sessions/{session_id}/export");
+    let resp = reqwest::get(&url).await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    resp.json::<String>().await.ok()
+}
+
 #[tauri::command]
-pub async fn bundle_bug_report(screenshots: Vec<String>) -> Result<BugReportResult, String> {
-    tokio::task::spawn_blocking(move || bundle_bug_report_impl(screenshots, None))
-        .await
-        .map_err(|e| format!("Bug report task failed: {e}"))?
+pub async fn bundle_bug_report(
+    app_handle: tauri::AppHandle,
+    screenshots: Vec<String>,
+    session_id: Option<String>,
+) -> Result<BugReportResult, String> {
+    let session_json = if let Some(ref sid) = session_id {
+        match crate::services::acp::GooseServeProcess::get(app_handle).await {
+            Ok(process) => {
+                let ws_url = process.ws_url();
+                let port = ws_url
+                    .split(':')
+                    .last()
+                    .and_then(|s| s.trim_end_matches("/acp").parse::<u16>().ok());
+                if let Some(port) = port {
+                    fetch_session_export(port, sid).await
+                } else {
+                    None
+                }
+            }
+            Err(_) => None,
+        }
+    } else {
+        None
+    };
+
+    tokio::task::spawn_blocking(move || {
+        bundle_bug_report_impl(screenshots, None, session_id, session_json)
+    })
+    .await
+    .map_err(|e| format!("Bug report task failed: {e}"))?
 }
 
 #[cfg(test)]
@@ -520,7 +568,7 @@ normal_setting: keep-this
         let output_dir = root.join("output");
         fs::create_dir_all(&output_dir).unwrap();
 
-        let result = bundle_bug_report_impl(vec![], Some(output_dir)).unwrap();
+        let result = bundle_bug_report_impl(vec![], Some(output_dir), None, None).unwrap();
         std::env::remove_var("GOOSE_PATH_ROOT");
 
         // Read the ZIP and verify excluded files are absent
@@ -538,16 +586,23 @@ normal_setting: keep-this
 
     #[test]
     fn manifest_has_environment_block() {
-        let manifest = build_manifest("_No recent errors._");
+        let manifest = build_manifest("_No recent errors._", None);
         assert!(manifest.contains("## Environment"));
         assert!(manifest.contains("App version:"));
         assert!(manifest.contains("Session: (none)"));
     }
 
     #[test]
+    fn manifest_shows_session_id_when_provided() {
+        let manifest = build_manifest("_No recent errors._", Some("abc-123"));
+        assert!(manifest.contains("Session: abc-123"));
+        assert!(!manifest.contains("(none)"));
+    }
+
+    #[test]
     fn manifest_includes_error_details() {
         let errors = "2026-01-01 ERROR something broke\n2026-01-01 WARN disk full";
-        let manifest = build_manifest(errors);
+        let manifest = build_manifest(errors, None);
         assert!(manifest.contains("<details>"));
         assert!(manifest.contains("something broke"));
         assert!(manifest.contains("disk full"));
@@ -599,7 +654,9 @@ normal_setting: keep-this
             "GOOSE_PATH_ROOT",
             dir.path().join("fake").to_string_lossy().as_ref(),
         );
-        let result = bundle_bug_report_impl(vec![png_b64.to_string()], Some(output_dir)).unwrap();
+        let result =
+            bundle_bug_report_impl(vec![png_b64.to_string()], Some(output_dir), None, None)
+                .unwrap();
         std::env::remove_var("GOOSE_PATH_ROOT");
 
         let file = fs::File::open(&result.zip_path).unwrap();
@@ -627,7 +684,7 @@ normal_setting: keep-this
         std::env::set_var("GOOSE_PATH_ROOT", root.to_string_lossy().as_ref());
         let output_dir = root.join("output");
         fs::create_dir_all(&output_dir).unwrap();
-        let result = bundle_bug_report_impl(vec![], Some(output_dir)).unwrap();
+        let result = bundle_bug_report_impl(vec![], Some(output_dir), None, None).unwrap();
         std::env::remove_var("GOOSE_PATH_ROOT");
 
         let file = fs::File::open(&result.zip_path).unwrap();
@@ -639,5 +696,65 @@ normal_setting: keep-this
 
         assert!(contents.contains("[REDACTED]"));
         assert!(!contents.contains("sk-abc123"));
+    }
+
+    #[test]
+    fn session_json_included_and_scrubbed() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        let (_state, _config, _data) = setup_fixture_dirs(root);
+
+        std::env::set_var("GOOSE_PATH_ROOT", root.to_string_lossy().as_ref());
+        let output_dir = root.join("output");
+        fs::create_dir_all(&output_dir).unwrap();
+
+        let session_json =
+            r#"{"id":"sess-1","messages":[{"content":"key sk-abc123def456ghi789jkl012345"}]}"#;
+
+        let result = bundle_bug_report_impl(
+            vec![],
+            Some(output_dir),
+            Some("sess-1".to_string()),
+            Some(session_json.to_string()),
+        )
+        .unwrap();
+        std::env::remove_var("GOOSE_PATH_ROOT");
+
+        assert!(result.manifest.contains("Session: sess-1"));
+
+        let file = fs::File::open(&result.zip_path).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+
+        let mut entry = archive.by_name("session.json").unwrap();
+        let mut contents = String::new();
+        entry.read_to_string(&mut contents).unwrap();
+
+        assert!(contents.contains("[REDACTED]"));
+        assert!(!contents.contains("sk-abc123"));
+        assert!(contents.contains("sess-1"));
+    }
+
+    #[test]
+    fn no_session_json_when_none_provided() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        let (_state, _config, _data) = setup_fixture_dirs(root);
+
+        std::env::set_var("GOOSE_PATH_ROOT", root.to_string_lossy().as_ref());
+        let output_dir = root.join("output");
+        fs::create_dir_all(&output_dir).unwrap();
+
+        let result = bundle_bug_report_impl(vec![], Some(output_dir), None, None).unwrap();
+        std::env::remove_var("GOOSE_PATH_ROOT");
+
+        assert!(result.manifest.contains("Session: (none)"));
+
+        let file = fs::File::open(&result.zip_path).unwrap();
+        let archive = zip::ZipArchive::new(file).unwrap();
+        let names: Vec<String> = (0..archive.len())
+            .map(|i| archive.by_index(i).unwrap().name().to_string())
+            .collect();
+
+        assert!(!names.contains(&"session.json".to_string()));
     }
 }

--- a/ui/tandem/src-tauri/src/commands/bug_report.rs
+++ b/ui/tandem/src-tauri/src/commands/bug_report.rs
@@ -1,0 +1,643 @@
+use base64::Engine;
+use chrono::Utc;
+use etcetera::{choose_app_strategy, AppStrategy, AppStrategyArgs};
+use regex::Regex;
+use serde::Serialize;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use zip::write::FileOptions;
+use zip::ZipWriter;
+
+const MAX_FILE_BYTES: u64 = 1_048_576; // 1 MB
+const OMISSION_MARKER: &str = "\n... ({} bytes omitted) ...\n";
+const TAIL_BYTES: usize = 4096;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BugReportResult {
+    pub zip_path: String,
+    pub manifest: String,
+}
+
+fn app_strategy() -> Option<AppStrategyArgs> {
+    Some(AppStrategyArgs {
+        top_level_domain: "Block".to_string(),
+        author: "Block".to_string(),
+        app_name: "goose".to_string(),
+    })
+}
+
+fn resolve_state_dir() -> Option<PathBuf> {
+    if let Ok(root) = std::env::var("GOOSE_PATH_ROOT") {
+        return Some(PathBuf::from(root).join("state"));
+    }
+    choose_app_strategy(app_strategy()?)
+        .ok()
+        .and_then(|s| s.state_dir())
+}
+
+fn resolve_config_dir() -> Option<PathBuf> {
+    if let Ok(root) = std::env::var("GOOSE_PATH_ROOT") {
+        return Some(PathBuf::from(root).join("config"));
+    }
+    choose_app_strategy(app_strategy()?)
+        .ok()
+        .map(|s| s.config_dir())
+}
+
+fn resolve_data_dir() -> Option<PathBuf> {
+    if let Ok(root) = std::env::var("GOOSE_PATH_ROOT") {
+        return Some(PathBuf::from(root).join("data"));
+    }
+    choose_app_strategy(app_strategy()?)
+        .ok()
+        .map(|s| s.data_dir())
+}
+
+fn build_secret_patterns() -> Vec<Regex> {
+    [
+        r"sk-ant-[A-Za-z0-9_\-]{20,}",
+        r"sk-[A-Za-z0-9_\-]{20,}",
+        r"ghp_[A-Za-z0-9]{36}",
+        r"github_pat_[A-Za-z0-9_]{82}",
+        r"xox[baprs]-[A-Za-z0-9\-]{10,}",
+        r"AKIA[0-9A-Z]{16}",
+        r"eyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+",
+        r#"Bearer\s+[A-Za-z0-9_.\-]+"#,
+        r#"(?i)"?authorization"?\s*:\s*"?[^"\n,}]+"#,
+    ]
+    .iter()
+    .filter_map(|p| Regex::new(p).ok())
+    .collect()
+}
+
+fn is_sensitive_yaml_key(key: &str) -> bool {
+    let lower = key.to_lowercase();
+    ["key", "secret", "token", "password", "credential", "auth"]
+        .iter()
+        .any(|k| lower.contains(k))
+}
+
+fn scrub_text(text: &str, patterns: &[Regex]) -> String {
+    let mut result = text.to_string();
+    for pattern in patterns {
+        result = pattern.replace_all(&result, "[REDACTED]").into_owned();
+    }
+    result
+}
+
+fn redact_yaml_value(value: &mut serde_yaml::Value) {
+    match value {
+        serde_yaml::Value::Mapping(map) => {
+            for (k, v) in map.iter_mut() {
+                let key_str = k.as_str().unwrap_or_default();
+                if is_sensitive_yaml_key(key_str) {
+                    *v = serde_yaml::Value::String("[REDACTED]".to_string());
+                } else {
+                    redact_yaml_value(v);
+                }
+            }
+        }
+        serde_yaml::Value::Sequence(seq) => {
+            for item in seq.iter_mut() {
+                redact_yaml_value(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn redact_config_yaml(contents: &str) -> String {
+    match serde_yaml::from_str::<serde_yaml::Value>(contents) {
+        Ok(mut value) => {
+            redact_yaml_value(&mut value);
+            serde_yaml::to_string(&value).unwrap_or_else(|_| "[REDACTED CONFIG]".to_string())
+        }
+        Err(_) => "[UNPARSEABLE CONFIG]".to_string(),
+    }
+}
+
+fn cap_file_content(raw: &[u8]) -> Vec<u8> {
+    if (raw.len() as u64) <= MAX_FILE_BYTES {
+        return raw.to_vec();
+    }
+
+    let head_bytes = (MAX_FILE_BYTES as usize) - TAIL_BYTES;
+    let omitted = raw.len() - head_bytes - TAIL_BYTES;
+    let marker = OMISSION_MARKER.replace("{}", &omitted.to_string());
+
+    let mut out = Vec::with_capacity(head_bytes + marker.len() + TAIL_BYTES);
+    out.extend_from_slice(&raw[..head_bytes]);
+    out.extend_from_slice(marker.as_bytes());
+    out.extend_from_slice(&raw[raw.len() - TAIL_BYTES..]);
+    out
+}
+
+fn find_latest_in_dir(dir: &Path) -> Option<PathBuf> {
+    std::fs::read_dir(dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|ft| ft.is_file()).unwrap_or(false))
+        .max_by_key(|e| e.metadata().and_then(|m| m.modified()).ok())
+        .map(|e| e.path())
+}
+
+fn find_latest_subdir(dir: &Path) -> Option<PathBuf> {
+    std::fs::read_dir(dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
+        .max_by_key(|e| e.file_name())
+        .map(|e| e.path())
+}
+
+fn find_latest_server_log(state_dir: &Path) -> Option<PathBuf> {
+    let server_log_dir = state_dir.join("logs").join("server");
+    let latest_date_dir = find_latest_subdir(&server_log_dir)?;
+    find_latest_in_dir(&latest_date_dir)
+}
+
+fn collect_jsonl_logs(state_dir: &Path) -> Vec<(String, PathBuf)> {
+    let logs_dir = state_dir.join("logs");
+    let mut entries = Vec::new();
+    if let Ok(reader) = std::fs::read_dir(&logs_dir) {
+        for entry in reader.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                if let Some(ext) = path.extension() {
+                    if ext == "jsonl" {
+                        let name = path
+                            .file_name()
+                            .unwrap_or_default()
+                            .to_string_lossy()
+                            .to_string();
+                        entries.push((format!("logs/{name}"), path));
+                    }
+                }
+            }
+        }
+    }
+    entries
+}
+
+fn extract_recent_errors(log_path: &Path, max_lines: usize) -> String {
+    let contents = match std::fs::read_to_string(log_path) {
+        Ok(c) => c,
+        Err(_) => return "_No recent errors._".to_string(),
+    };
+
+    let error_lines: Vec<&str> = contents
+        .lines()
+        .filter(|line| {
+            let upper = line.to_uppercase();
+            upper.contains("WARN") || upper.contains("ERROR")
+        })
+        .collect();
+
+    if error_lines.is_empty() {
+        return "_No recent errors._".to_string();
+    }
+
+    let start = error_lines.len().saturating_sub(max_lines);
+    error_lines[start..].join("\n")
+}
+
+fn build_system_txt() -> String {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+    let timestamp = Utc::now().to_rfc3339();
+    let app_version = env!("CARGO_PKG_VERSION");
+
+    format!("OS: {os}\nArch: {arch}\nApp version: {app_version}\nTimestamp: {timestamp}\n")
+}
+
+fn resolve_output_dir() -> PathBuf {
+    if let Some(dl) = dirs::download_dir() {
+        if dl.is_dir() {
+            return dl;
+        }
+    }
+    if let Some(home) = dirs::home_dir() {
+        if home.is_dir() {
+            return home;
+        }
+    }
+    std::env::temp_dir()
+}
+
+fn build_manifest(recent_errors: &str) -> String {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+    let app_version = env!("CARGO_PKG_VERSION");
+
+    let errors_section = if recent_errors == "_No recent errors._" {
+        format!("_No recent errors._")
+    } else {
+        format!("<details>\n<summary>Last errors/warnings</summary>\n\n```\n{recent_errors}\n```\n</details>")
+    };
+
+    format!(
+        "## Environment\n\n\
+         - App version: {app_version}\n\
+         - OS: {os}\n\
+         - Arch: {arch}\n\
+         - Session: (none)\n\n\
+         ## Recent errors\n\n\
+         {errors_section}\n\n\
+         ## Diagnostics\n\n\
+         _See attached ZIP file._\n"
+    )
+}
+
+fn add_file_to_zip<W: Write + std::io::Seek>(
+    zip: &mut ZipWriter<W>,
+    zip_name: &str,
+    content: &[u8],
+) -> Result<(), String> {
+    let options = FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+    zip.start_file(zip_name, options)
+        .map_err(|e| format!("Failed to start ZIP entry '{zip_name}': {e}"))?;
+    zip.write_all(content)
+        .map_err(|e| format!("Failed to write ZIP entry '{zip_name}': {e}"))?;
+    Ok(())
+}
+
+pub fn bundle_bug_report_impl(
+    screenshots: Vec<String>,
+    output_dir: Option<PathBuf>,
+) -> Result<BugReportResult, String> {
+    let secret_patterns = build_secret_patterns();
+    let state_dir = resolve_state_dir();
+    let config_dir = resolve_config_dir();
+    let data_dir = resolve_data_dir();
+
+    let out_dir = output_dir.unwrap_or_else(resolve_output_dir);
+    let timestamp = Utc::now().format("%Y%m%dT%H%M%S").to_string();
+    let zip_filename = format!("tandem-bug-{timestamp}.zip");
+    let zip_path = out_dir.join(&zip_filename);
+
+    let file =
+        std::fs::File::create(&zip_path).map_err(|e| format!("Failed to create ZIP file: {e}"))?;
+    let mut zip = ZipWriter::new(file);
+
+    // system.txt
+    let system_txt = build_system_txt();
+    add_file_to_zip(&mut zip, "system.txt", system_txt.as_bytes())?;
+
+    // config.yaml (redacted by key)
+    if let Some(ref cfg_dir) = config_dir {
+        let config_path = cfg_dir.join("config.yaml");
+        if config_path.is_file() {
+            if let Ok(contents) = std::fs::read_to_string(&config_path) {
+                let redacted = redact_config_yaml(&contents);
+                add_file_to_zip(&mut zip, "config.yaml", redacted.as_bytes())?;
+            }
+        }
+    }
+
+    // schedule.json
+    if let Some(ref d_dir) = data_dir {
+        let schedule_path = d_dir.join("schedule.json");
+        if schedule_path.is_file() {
+            if let Ok(raw) = std::fs::read(&schedule_path) {
+                let capped = cap_file_content(&raw);
+                let text = String::from_utf8_lossy(&capped);
+                let scrubbed = scrub_text(&text, &secret_patterns);
+                add_file_to_zip(&mut zip, "schedule.json", scrubbed.as_bytes())?;
+            }
+        }
+    }
+
+    // JSONL logs from state_dir/logs/
+    if let Some(ref s_dir) = state_dir {
+        for (zip_name, path) in collect_jsonl_logs(s_dir) {
+            if let Ok(raw) = std::fs::read(&path) {
+                let capped = cap_file_content(&raw);
+                let text = String::from_utf8_lossy(&capped);
+                let scrubbed = scrub_text(&text, &secret_patterns);
+                add_file_to_zip(&mut zip, &zip_name, scrubbed.as_bytes())?;
+            }
+        }
+    }
+
+    // Latest server log
+    let mut recent_errors = "_No recent errors._".to_string();
+    if let Some(ref s_dir) = state_dir {
+        if let Some(log_path) = find_latest_server_log(s_dir) {
+            recent_errors = extract_recent_errors(&log_path, 20);
+            let recent_errors_scrubbed = scrub_text(&recent_errors, &secret_patterns);
+            recent_errors = recent_errors_scrubbed;
+
+            if let Ok(raw) = std::fs::read(&log_path) {
+                let capped = cap_file_content(&raw);
+                let text = String::from_utf8_lossy(&capped);
+                let scrubbed = scrub_text(&text, &secret_patterns);
+                add_file_to_zip(&mut zip, "server.log", scrubbed.as_bytes())?;
+            }
+        }
+    }
+
+    // Screenshots (base64 -> PNG)
+    for (i, b64) in screenshots.iter().enumerate() {
+        match base64::engine::general_purpose::STANDARD.decode(b64) {
+            Ok(bytes) => {
+                let name = format!("screenshot-{}.png", i + 1);
+                add_file_to_zip(&mut zip, &name, &bytes)?;
+            }
+            Err(e) => {
+                log::warn!("Skipping screenshot {}: {e}", i + 1);
+            }
+        }
+    }
+
+    zip.finish()
+        .map_err(|e| format!("Failed to finalize ZIP: {e}"))?;
+
+    let manifest = build_manifest(&recent_errors);
+
+    Ok(BugReportResult {
+        zip_path: zip_path.to_string_lossy().into_owned(),
+        manifest,
+    })
+}
+
+#[tauri::command]
+pub async fn bundle_bug_report(screenshots: Vec<String>) -> Result<BugReportResult, String> {
+    tokio::task::spawn_blocking(move || bundle_bug_report_impl(screenshots, None))
+        .await
+        .map_err(|e| format!("Bug report task failed: {e}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn setup_fixture_dirs(root: &Path) -> (PathBuf, PathBuf, PathBuf) {
+        let state = root.join("state");
+        let config = root.join("config");
+        let data = root.join("data");
+        fs::create_dir_all(state.join("logs").join("server").join("2026-01-01")).unwrap();
+        fs::create_dir_all(&config).unwrap();
+        fs::create_dir_all(&data).unwrap();
+        (state, config, data)
+    }
+
+    #[test]
+    fn scrub_removes_openai_key() {
+        let patterns = build_secret_patterns();
+        let input = "my key is sk-abc123def456ghi789jkl012345";
+        let result = scrub_text(input, &patterns);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("sk-abc123"));
+    }
+
+    #[test]
+    fn scrub_removes_anthropic_key() {
+        let patterns = build_secret_patterns();
+        let input = "key: sk-ant-abcdefghijklmnopqrstuvwxyz1234567890";
+        let result = scrub_text(input, &patterns);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("sk-ant-"));
+    }
+
+    #[test]
+    fn scrub_removes_github_pat() {
+        let patterns = build_secret_patterns();
+        let input = "token: ghp_AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDDEEEE";
+        let result = scrub_text(input, &patterns);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("ghp_"));
+    }
+
+    #[test]
+    fn scrub_removes_github_fine_grained_pat() {
+        let patterns = build_secret_patterns();
+        let long_pat = format!("github_pat_{}", "A".repeat(82));
+        let input = format!("token: {long_pat}");
+        let result = scrub_text(&input, &patterns);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("github_pat_"));
+    }
+
+    #[test]
+    fn scrub_removes_slack_token() {
+        let patterns = build_secret_patterns();
+        let input = "SLACK_TOKEN=xoxb-1234567890-abcdef";
+        let result = scrub_text(input, &patterns);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("xoxb-"));
+    }
+
+    #[test]
+    fn scrub_removes_aws_key() {
+        let patterns = build_secret_patterns();
+        let input = "aws_key = AKIAIOSFODNN7EXAMPLE";
+        let result = scrub_text(input, &patterns);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("AKIA"));
+    }
+
+    #[test]
+    fn scrub_removes_bearer_token() {
+        let patterns = build_secret_patterns();
+        let input = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.test.sig";
+        let result = scrub_text(input, &patterns);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("Bearer eyJ"));
+    }
+
+    #[test]
+    fn scrub_removes_authorization_header() {
+        let patterns = build_secret_patterns();
+        let input = r#""authorization": "Basic dXNlcjpwYXNz""#;
+        let result = scrub_text(input, &patterns);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("dXNlcjpwYXNz"));
+    }
+
+    #[test]
+    fn scrub_preserves_safe_text() {
+        let patterns = build_secret_patterns();
+        let input = "This is a normal log line with no secrets";
+        let result = scrub_text(input, &patterns);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn redact_yaml_replaces_sensitive_keys() {
+        let yaml = r#"
+OPENAI_API_KEY: sk-real-key-here
+GOOSE_MODEL: gpt-4
+database_password: hunter2
+auth_token: abc123
+normal_setting: keep-this
+"#;
+        let result = redact_config_yaml(yaml);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("sk-real-key-here"));
+        assert!(!result.contains("hunter2"));
+        assert!(!result.contains("abc123"));
+        assert!(result.contains("keep-this"));
+        assert!(result.contains("gpt-4"));
+    }
+
+    #[test]
+    fn cap_file_content_passes_small_file() {
+        let content = b"small file";
+        let result = cap_file_content(content);
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn cap_file_content_truncates_large_file() {
+        let big = vec![b'x'; 2_000_000];
+        let result = cap_file_content(&big);
+        assert!((result.len() as u64) <= MAX_FILE_BYTES + 200);
+        let text = String::from_utf8_lossy(&result);
+        assert!(text.contains("bytes omitted"));
+    }
+
+    #[test]
+    fn bundle_excludes_prompts_and_scheduled_recipes() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        let (state, config, data) = setup_fixture_dirs(root);
+
+        // Create excluded directories with files
+        let prompts_dir = data.join("prompts");
+        let recipes_dir = data.join("scheduled_recipes");
+        fs::create_dir_all(&prompts_dir).unwrap();
+        fs::create_dir_all(&recipes_dir).unwrap();
+        fs::write(prompts_dir.join("test.txt"), "should not appear").unwrap();
+        fs::write(recipes_dir.join("recipe.yaml"), "should not appear").unwrap();
+
+        // Create config.yaml so there's something to bundle
+        fs::write(config.join("config.yaml"), "model: gpt-4\n").unwrap();
+
+        std::env::set_var("GOOSE_PATH_ROOT", root.to_string_lossy().as_ref());
+        let output_dir = root.join("output");
+        fs::create_dir_all(&output_dir).unwrap();
+
+        let result = bundle_bug_report_impl(vec![], Some(output_dir)).unwrap();
+        std::env::remove_var("GOOSE_PATH_ROOT");
+
+        // Read the ZIP and verify excluded files are absent
+        let file = fs::File::open(&result.zip_path).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+        let names: Vec<String> = (0..archive.len())
+            .map(|i| archive.by_index(i).unwrap().name().to_string())
+            .collect();
+
+        assert!(!names.iter().any(|n| n.contains("prompts")));
+        assert!(!names.iter().any(|n| n.contains("scheduled_recipes")));
+        assert!(names.contains(&"system.txt".to_string()));
+        assert!(names.contains(&"config.yaml".to_string()));
+    }
+
+    #[test]
+    fn manifest_has_environment_block() {
+        let manifest = build_manifest("_No recent errors._");
+        assert!(manifest.contains("## Environment"));
+        assert!(manifest.contains("App version:"));
+        assert!(manifest.contains("Session: (none)"));
+    }
+
+    #[test]
+    fn manifest_includes_error_details() {
+        let errors = "2026-01-01 ERROR something broke\n2026-01-01 WARN disk full";
+        let manifest = build_manifest(errors);
+        assert!(manifest.contains("<details>"));
+        assert!(manifest.contains("something broke"));
+        assert!(manifest.contains("disk full"));
+    }
+
+    #[test]
+    fn extract_recent_errors_from_log() {
+        let dir = tempdir().unwrap();
+        let log_path = dir.path().join("test.log");
+        let content = (0..30)
+            .map(|i| {
+                if i % 5 == 0 {
+                    format!("2026-01-01 ERROR failure {i}")
+                } else if i % 7 == 0 {
+                    format!("2026-01-01 WARN warning {i}")
+                } else {
+                    format!("2026-01-01 INFO normal {i}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(&log_path, content).unwrap();
+
+        let result = extract_recent_errors(&log_path, 5);
+        let lines: Vec<&str> = result.lines().collect();
+        assert!(lines.len() <= 5);
+        assert!(lines
+            .iter()
+            .all(|l| l.contains("ERROR") || l.contains("WARN")));
+    }
+
+    #[test]
+    fn extract_recent_errors_returns_fallback_on_missing_file() {
+        let missing = PathBuf::from("/nonexistent/path/log.txt");
+        let result = extract_recent_errors(&missing, 20);
+        assert_eq!(result, "_No recent errors._");
+    }
+
+    #[test]
+    fn screenshots_written_to_zip() {
+        let dir = tempdir().unwrap();
+        let output_dir = dir.path().join("output");
+        fs::create_dir_all(&output_dir).unwrap();
+
+        // 1x1 red PNG
+        let png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+
+        std::env::set_var(
+            "GOOSE_PATH_ROOT",
+            dir.path().join("fake").to_string_lossy().as_ref(),
+        );
+        let result = bundle_bug_report_impl(vec![png_b64.to_string()], Some(output_dir)).unwrap();
+        std::env::remove_var("GOOSE_PATH_ROOT");
+
+        let file = fs::File::open(&result.zip_path).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+        let names: Vec<String> = (0..archive.len())
+            .map(|i| archive.by_index(i).unwrap().name().to_string())
+            .collect();
+
+        assert!(names.contains(&"screenshot-1.png".to_string()));
+    }
+
+    #[test]
+    fn scrubbed_server_log_in_zip() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        let (state, _config, _data) = setup_fixture_dirs(root);
+
+        let log_dir = state.join("logs").join("server").join("2026-01-01");
+        fs::write(
+            log_dir.join("server.log"),
+            "INFO normal\nERROR secret key sk-abc123def456ghi789jkl012345 leaked\n",
+        )
+        .unwrap();
+
+        std::env::set_var("GOOSE_PATH_ROOT", root.to_string_lossy().as_ref());
+        let output_dir = root.join("output");
+        fs::create_dir_all(&output_dir).unwrap();
+        let result = bundle_bug_report_impl(vec![], Some(output_dir)).unwrap();
+        std::env::remove_var("GOOSE_PATH_ROOT");
+
+        let file = fs::File::open(&result.zip_path).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+
+        let mut log_entry = archive.by_name("server.log").unwrap();
+        let mut contents = String::new();
+        log_entry.read_to_string(&mut contents).unwrap();
+
+        assert!(contents.contains("[REDACTED]"));
+        assert!(!contents.contains("sk-abc123"));
+    }
+}

--- a/ui/tandem/src-tauri/src/commands/mod.rs
+++ b/ui/tandem/src-tauri/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub mod path_resolver;
 pub mod projects;
 pub mod skills;
 pub mod system;
+pub mod telemetry;

--- a/ui/tandem/src-tauri/src/commands/mod.rs
+++ b/ui/tandem/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod acp;
 pub mod agent_setup;
 pub mod agents;
+pub mod bug_report;
 pub mod credentials;
 pub mod doctor;
 pub mod extensions;

--- a/ui/tandem/src-tauri/src/commands/telemetry.rs
+++ b/ui/tandem/src-tauri/src/commands/telemetry.rs
@@ -1,0 +1,19 @@
+use crate::services::goose_config::GooseConfig;
+use tauri::State;
+
+#[tauri::command]
+pub fn is_telemetry_disabled(config: State<GooseConfig>) -> bool {
+    if let Ok(val) = std::env::var("GOOSE_TELEMETRY_OFF") {
+        if val == "1" || val.eq_ignore_ascii_case("true") {
+            return true;
+        }
+    }
+
+    if let Some(val) = config.get_param("GOOSE_TELEMETRY_ENABLED") {
+        if val.eq_ignore_ascii_case("false") || val == "0" {
+            return true;
+        }
+    }
+
+    false
+}

--- a/ui/tandem/src-tauri/src/lib.rs
+++ b/ui/tandem/src-tauri/src/lib.rs
@@ -93,6 +93,7 @@ pub fn run() {
             commands::system::list_files_for_mentions,
             commands::system::read_image_attachment,
             commands::system::read_text_file,
+            commands::bug_report::bundle_bug_report,
         ])
         .setup(|_app| Ok(()))
         .build(tauri::generate_context!())

--- a/ui/tandem/src-tauri/src/lib.rs
+++ b/ui/tandem/src-tauri/src/lib.rs
@@ -94,6 +94,7 @@ pub fn run() {
             commands::system::read_image_attachment,
             commands::system::read_text_file,
             commands::bug_report::bundle_bug_report,
+            commands::telemetry::is_telemetry_disabled,
         ])
         .setup(|_app| Ok(()))
         .build(tauri::generate_context!())

--- a/ui/tandem/src/features/bugReport/lib/__tests__/telemetry.test.ts
+++ b/ui/tandem/src/features/bugReport/lib/__tests__/telemetry.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { emitBugReportSubmitted } from "../telemetry";
+
+const mockInvoke = vi.fn();
+const mockFetch = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetch.mockResolvedValue({ ok: true });
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+describe("emitBugReportSubmitted", () => {
+  it("skips fetch when telemetry is disabled", async () => {
+    mockInvoke.mockResolvedValue(true);
+
+    await emitBugReportSubmitted({
+      has_description: true,
+      has_screenshot: false,
+      has_session: false,
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith("is_telemetry_disabled");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("sends fetch with expected payload when telemetry is enabled", async () => {
+    mockInvoke.mockResolvedValue(false);
+
+    await emitBugReportSubmitted({
+      has_description: true,
+      has_screenshot: true,
+      has_session: false,
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://us.i.posthog.com/capture/");
+    expect(options.method).toBe("POST");
+
+    const body = JSON.parse(options.body as string);
+    expect(body.event).toBe("bug_report_submitted");
+    expect(body.properties).toEqual({
+      has_description: true,
+      has_screenshot: true,
+      has_session: false,
+    });
+    expect(body.api_key).toBe(
+      "phc_RyX5CaY01VtZJCQyhSR5KFh6qimUy81YwxsEpotAftT",
+    );
+  });
+
+  it("does not throw when fetch fails", async () => {
+    mockInvoke.mockResolvedValue(false);
+    mockFetch.mockRejectedValue(new Error("network error"));
+
+    await expect(
+      emitBugReportSubmitted({
+        has_description: false,
+        has_screenshot: false,
+        has_session: false,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not throw when invoke fails", async () => {
+    mockInvoke.mockRejectedValue(new Error("tauri error"));
+
+    await expect(
+      emitBugReportSubmitted({
+        has_description: false,
+        has_screenshot: false,
+        has_session: false,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/ui/tandem/src/features/bugReport/lib/telemetry.ts
+++ b/ui/tandem/src/features/bugReport/lib/telemetry.ts
@@ -1,0 +1,37 @@
+import { invoke } from "@tauri-apps/api/core";
+
+const POSTHOG_API_KEY = "phc_RyX5CaY01VtZJCQyhSR5KFh6qimUy81YwxsEpotAftT";
+const POSTHOG_CAPTURE_URL = "https://us.i.posthog.com/capture/";
+
+interface BugReportPayload {
+  has_description: boolean;
+  has_screenshot: boolean;
+  has_session: boolean;
+}
+
+export async function emitBugReportSubmitted(
+  payload: BugReportPayload,
+): Promise<void> {
+  try {
+    const disabled = await invoke<boolean>("is_telemetry_disabled");
+    if (disabled) return;
+
+    await fetch(POSTHOG_CAPTURE_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_key: POSTHOG_API_KEY,
+        event: "bug_report_submitted",
+        distinct_id: "tandem-desktop",
+        properties: {
+          has_description: payload.has_description,
+          has_screenshot: payload.has_screenshot,
+          has_session: payload.has_session,
+        },
+        timestamp: new Date().toISOString(),
+      }),
+    });
+  } catch {
+    // Silent — never block the user or surface errors
+  }
+}

--- a/ui/tandem/src/features/bugReport/ui/BugReportButton.tsx
+++ b/ui/tandem/src/features/bugReport/ui/BugReportButton.tsx
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Bug } from "lucide-react";
+import { Button } from "@/shared/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/shared/ui/tooltip";
+import { BugReportModal } from "./BugReportModal";
+
+export function BugReportButton() {
+  const { t } = useTranslation("bugReport");
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => setOpen(true)}
+            aria-label={t("button.label")}
+          >
+            <Bug className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t("button.label")}</TooltipContent>
+      </Tooltip>
+      <BugReportModal open={open} onOpenChange={setOpen} />
+    </>
+  );
+}

--- a/ui/tandem/src/features/bugReport/ui/BugReportModal.tsx
+++ b/ui/tandem/src/features/bugReport/ui/BugReportModal.tsx
@@ -1,10 +1,13 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { X } from "lucide-react";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { Label } from "@/shared/ui/label";
 import { Textarea } from "@/shared/ui/textarea";
+import { Spinner } from "@/shared/ui/spinner";
 import {
   Dialog,
   DialogContent,
@@ -17,14 +20,53 @@ import {
 const REPO_URL = "https://github.com/larkinmaxim/tandem";
 const MIN_TITLE_LENGTH = 3;
 const MAX_DESCRIPTION_LENGTH = 8000;
+const MAX_SCREENSHOT_BYTES = 10 * 1024 * 1024;
+const TRUNCATION_SUFFIX = "... ({{n}} chars omitted)";
 
-function buildIssueUrl(title: string, description: string): string {
+interface BundleResult {
+  zipPath: string;
+  manifest: string;
+}
+
+function buildIssueUrl(
+  title: string,
+  description: string,
+  manifest: string,
+): string {
   const params = new URLSearchParams();
   params.set("title", title.trim());
+
+  let body = "";
   if (description.trim()) {
-    params.set("body", description.trim());
+    let desc = description.trim();
+    if (desc.length > MAX_DESCRIPTION_LENGTH) {
+      const omitted = desc.length - MAX_DESCRIPTION_LENGTH;
+      desc =
+        desc.slice(0, MAX_DESCRIPTION_LENGTH) +
+        TRUNCATION_SUFFIX.replace("{{n}}", String(omitted));
+    }
+    body = desc;
+  }
+  if (manifest) {
+    body = body ? `${body}\n\n---\n\n${manifest}` : manifest;
+  }
+  if (body) {
+    params.set("body", body);
   }
   return `${REPO_URL}/issues/new?${params.toString()}`;
+}
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const dataUrl = reader.result as string;
+      const base64 = dataUrl.split(",")[1] ?? "";
+      resolve(base64);
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
 }
 
 interface BugReportModalProps {
@@ -36,28 +78,94 @@ export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
   const { t } = useTranslation("bugReport");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [screenshots, setScreenshots] = useState<string[]>([]);
+  const [screenshotError, setScreenshotError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const trimmedTitle = title.trim();
-  const canSubmit = trimmedTitle.length >= MIN_TITLE_LENGTH;
+  const canSubmit = trimmedTitle.length >= MIN_TITLE_LENGTH && !submitting;
+  const showTruncation = description.length > MAX_DESCRIPTION_LENGTH;
+
+  const handlePaste = useCallback(
+    async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+
+      let hasImage = false;
+      for (const item of items) {
+        if (item.type.startsWith("image/")) {
+          hasImage = true;
+          const blob = item.getAsFile();
+          if (!blob) continue;
+
+          if (blob.size > MAX_SCREENSHOT_BYTES) {
+            const sizeMb = Math.round(blob.size / (1024 * 1024));
+            setScreenshotError(
+              t("modal.screenshotTooLarge", { size: sizeMb }),
+            );
+            e.preventDefault();
+            return;
+          }
+
+          setScreenshotError(null);
+          const base64 = await blobToBase64(blob);
+          setScreenshots((prev) => [...prev, base64]);
+        }
+      }
+
+      if (hasImage) {
+        e.preventDefault();
+      }
+    },
+    [t],
+  );
+
+  const removeScreenshot = (index: number) => {
+    setScreenshots((prev) => prev.filter((_, i) => i !== index));
+    setScreenshotError(null);
+  };
 
   const handleSubmit = async () => {
     if (!canSubmit) return;
-    const url = buildIssueUrl(trimmedTitle, description);
-    await openUrl(url);
-    setTitle("");
-    setDescription("");
-    onOpenChange(false);
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const result = await invoke<BundleResult>("bundle_bug_report", {
+        screenshots,
+      });
+
+      const url = buildIssueUrl(trimmedTitle, description, result.manifest);
+      await openUrl(url);
+
+      setTitle("");
+      setDescription("");
+      setScreenshots([]);
+      setScreenshotError(null);
+      onOpenChange(false);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      setError(t("modal.error", { reason }));
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const handleCancel = () => {
+    if (submitting) return;
     setTitle("");
     setDescription("");
+    setScreenshots([]);
+    setScreenshotError(null);
+    setError(null);
     onOpenChange(false);
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+    <Dialog open={open} onOpenChange={submitting ? undefined : onOpenChange}>
+      <DialogContent className="sm:max-w-md" showCloseButton={!submitting}>
         <DialogHeader>
           <DialogTitle>{t("modal.title")}</DialogTitle>
           <DialogDescription>{t("modal.description")}</DialogDescription>
@@ -71,8 +179,9 @@ export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               placeholder={t("modal.titlePlaceholder")}
+              disabled={submitting}
             />
-            {title.length > 0 && !canSubmit && (
+            {title.length > 0 && trimmedTitle.length < MIN_TITLE_LENGTH && (
               <p className="text-xs text-destructive">
                 {t("modal.titleValidation")}
               </p>
@@ -86,26 +195,84 @@ export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
             <Textarea
               id="bug-report-description"
               value={description}
-              onChange={(e) =>
-                setDescription(e.target.value.slice(0, MAX_DESCRIPTION_LENGTH))
-              }
+              onChange={(e) => setDescription(e.target.value)}
+              onPaste={handlePaste}
               placeholder={t("modal.descriptionPlaceholder")}
               rows={4}
+              disabled={submitting}
             />
+            {showTruncation && (
+              <p className="text-xs text-amber-600">
+                {t("modal.truncationNotice", {
+                  limit: MAX_DESCRIPTION_LENGTH,
+                  excess: description.length - MAX_DESCRIPTION_LENGTH,
+                })}
+              </p>
+            )}
           </div>
+
+          {screenshotError && (
+            <p className="text-xs text-destructive">{screenshotError}</p>
+          )}
+
+          {screenshots.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {screenshots.map((_, i) => (
+                <span
+                  key={i}
+                  className="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-1 text-xs"
+                >
+                  📎 {t("modal.screenshotChip", { index: i + 1 })}
+                  <button
+                    type="button"
+                    onClick={() => removeScreenshot(i)}
+                    className="ml-0.5 rounded-full p-0.5 hover:bg-muted-foreground/20"
+                    aria-label={t("modal.removeScreenshot", { index: i + 1 })}
+                    disabled={submitting}
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+
+          {error && (
+            <p className="text-xs text-destructive" role="alert">
+              {error}
+            </p>
+          )}
         </div>
 
         <DialogFooter>
-          <Button type="button" variant="outline" onClick={handleCancel}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleCancel}
+            disabled={submitting}
+          >
             {t("modal.cancel")}
           </Button>
-          <Button type="button" disabled={!canSubmit} onClick={handleSubmit}>
-            {t("modal.submit")}
-          </Button>
+          {error ? (
+            <Button type="button" onClick={handleSubmit} disabled={!canSubmit}>
+              {t("modal.retry")}
+            </Button>
+          ) : (
+            <Button type="button" disabled={!canSubmit} onClick={handleSubmit}>
+              {submitting ? (
+                <>
+                  <Spinner className="mr-2" />
+                  {t("modal.submitting")}
+                </>
+              ) : (
+                t("modal.submit")
+              )}
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>
   );
 }
 
-export { buildIssueUrl, MIN_TITLE_LENGTH };
+export { buildIssueUrl, blobToBase64, MIN_TITLE_LENGTH, MAX_DESCRIPTION_LENGTH };

--- a/ui/tandem/src/features/bugReport/ui/BugReportModal.tsx
+++ b/ui/tandem/src/features/bugReport/ui/BugReportModal.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/shared/ui/dialog";
 import { revealInFileManager } from "@/shared/lib/fileManager";
 import { getPlatform } from "@/shared/lib/platform";
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import { emitBugReportSubmitted } from "../lib/telemetry";
 
 const REPO_URL = "https://github.com/larkinmaxim/tandem";
@@ -110,6 +111,7 @@ interface BugReportModalProps {
 
 export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
   const { t } = useTranslation("bugReport");
+  const activeSessionId = useChatSessionStore((s) => s.activeSessionId);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [screenshots, setScreenshots] = useState<string[]>([]);
@@ -169,6 +171,7 @@ export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
     try {
       const result = await invoke<BundleResult>("bundle_bug_report", {
         screenshots,
+        sessionId: activeSessionId ?? undefined,
       });
 
       const url = buildIssueUrl(trimmedTitle, description, result.manifest);
@@ -185,7 +188,7 @@ export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
       void emitBugReportSubmitted({
         has_description: description.trim().length > 0,
         has_screenshot: screenshots.length > 0,
-        has_session: false,
+        has_session: activeSessionId != null,
       });
 
       setTitle("");

--- a/ui/tandem/src/features/bugReport/ui/BugReportModal.tsx
+++ b/ui/tandem/src/features/bugReport/ui/BugReportModal.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+import { Label } from "@/shared/ui/label";
+import { Textarea } from "@/shared/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
+
+const REPO_URL = "https://github.com/larkinmaxim/tandem";
+const MIN_TITLE_LENGTH = 3;
+const MAX_DESCRIPTION_LENGTH = 8000;
+
+function buildIssueUrl(title: string, description: string): string {
+  const params = new URLSearchParams();
+  params.set("title", title.trim());
+  if (description.trim()) {
+    params.set("body", description.trim());
+  }
+  return `${REPO_URL}/issues/new?${params.toString()}`;
+}
+
+interface BugReportModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
+  const { t } = useTranslation("bugReport");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+
+  const trimmedTitle = title.trim();
+  const canSubmit = trimmedTitle.length >= MIN_TITLE_LENGTH;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    const url = buildIssueUrl(trimmedTitle, description);
+    await openUrl(url);
+    setTitle("");
+    setDescription("");
+    onOpenChange(false);
+  };
+
+  const handleCancel = () => {
+    setTitle("");
+    setDescription("");
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("modal.title")}</DialogTitle>
+          <DialogDescription>{t("modal.description")}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="bug-report-title">{t("modal.titleLabel")}</Label>
+            <Input
+              id="bug-report-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={t("modal.titlePlaceholder")}
+            />
+            {title.length > 0 && !canSubmit && (
+              <p className="text-xs text-destructive">
+                {t("modal.titleValidation")}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="bug-report-description">
+              {t("modal.descriptionLabel")}
+            </Label>
+            <Textarea
+              id="bug-report-description"
+              value={description}
+              onChange={(e) =>
+                setDescription(e.target.value.slice(0, MAX_DESCRIPTION_LENGTH))
+              }
+              placeholder={t("modal.descriptionPlaceholder")}
+              rows={4}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={handleCancel}>
+            {t("modal.cancel")}
+          </Button>
+          <Button type="button" disabled={!canSubmit} onClick={handleSubmit}>
+            {t("modal.submit")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export { buildIssueUrl, MIN_TITLE_LENGTH };

--- a/ui/tandem/src/features/bugReport/ui/BugReportModal.tsx
+++ b/ui/tandem/src/features/bugReport/ui/BugReportModal.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { toast } from "sonner";
 import { X } from "lucide-react";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
@@ -16,6 +17,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/shared/ui/dialog";
+import { revealInFileManager } from "@/shared/lib/fileManager";
+import { getPlatform } from "@/shared/lib/platform";
 import { emitBugReportSubmitted } from "../lib/telemetry";
 
 const REPO_URL = "https://github.com/larkinmaxim/tandem";
@@ -67,6 +70,36 @@ function blobToBase64(blob: Blob): Promise<string> {
     };
     reader.onerror = reject;
     reader.readAsDataURL(blob);
+  });
+}
+
+function getRevealLabel(t: (key: string) => string): string {
+  const platform = getPlatform();
+  if (platform === "mac") return t("toast.revealInFinder");
+  if (platform === "windows") return t("toast.revealInExplorer");
+  return t("toast.revealInFileManager");
+}
+
+function showSuccessToast(
+  t: (key: string, opts?: Record<string, unknown>) => string,
+  zipPath: string,
+  zipFilename: string,
+  browserFailed: boolean,
+) {
+  const message = browserFailed
+    ? t("toast.browserFailed")
+    : t("toast.success", { filename: zipFilename });
+
+  toast(message, {
+    duration: Infinity,
+    action: {
+      label: getRevealLabel(t),
+      onClick: () => void revealInFileManager(zipPath),
+    },
+    cancel: {
+      label: t("toast.copyPath"),
+      onClick: () => void navigator.clipboard.writeText(zipPath),
+    },
   });
 }
 
@@ -139,7 +172,15 @@ export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
       });
 
       const url = buildIssueUrl(trimmedTitle, description, result.manifest);
-      await openUrl(url);
+      const zipFilename = result.zipPath.split(/[/\\]/).pop() ?? "bundle.zip";
+
+      let browserFailed = false;
+      try {
+        await openUrl(url);
+      } catch {
+        browserFailed = true;
+        await navigator.clipboard.writeText(url).catch(() => {});
+      }
 
       void emitBugReportSubmitted({
         has_description: description.trim().length > 0,
@@ -152,6 +193,8 @@ export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
       setScreenshots([]);
       setScreenshotError(null);
       onOpenChange(false);
+
+      showSuccessToast(t, result.zipPath, zipFilename, browserFailed);
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       setError(t("modal.error", { reason }));

--- a/ui/tandem/src/features/bugReport/ui/BugReportModal.tsx
+++ b/ui/tandem/src/features/bugReport/ui/BugReportModal.tsx
@@ -16,6 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/shared/ui/dialog";
+import { emitBugReportSubmitted } from "../lib/telemetry";
 
 const REPO_URL = "https://github.com/larkinmaxim/tandem";
 const MIN_TITLE_LENGTH = 3;
@@ -139,6 +140,12 @@ export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
 
       const url = buildIssueUrl(trimmedTitle, description, result.manifest);
       await openUrl(url);
+
+      void emitBugReportSubmitted({
+        has_description: description.trim().length > 0,
+        has_screenshot: screenshots.length > 0,
+        has_session: false,
+      });
 
       setTitle("");
       setDescription("");

--- a/ui/tandem/src/features/bugReport/ui/__tests__/BugReportModal.test.tsx
+++ b/ui/tandem/src/features/bugReport/ui/__tests__/BugReportModal.test.tsx
@@ -9,6 +9,8 @@ import {
 
 const mockOpenUrl = vi.fn().mockResolvedValue(undefined);
 const mockInvoke = vi.fn();
+const mockToast = vi.fn();
+const mockRevealInFileManager = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: (...args: unknown[]) => mockOpenUrl(...args),
@@ -16,6 +18,18 @@ vi.mock("@tauri-apps/plugin-opener", () => ({
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+}));
+
+vi.mock("@/shared/lib/fileManager", () => ({
+  revealInFileManager: (...args: unknown[]) => mockRevealInFileManager(...args),
+}));
+
+vi.mock("@/shared/lib/platform", () => ({
+  getPlatform: () => "linux",
 }));
 
 const defaultProps = {
@@ -397,6 +411,76 @@ describe("BugReportModal", () => {
 
       expect(onOpenChange).toHaveBeenCalledWith(false);
       expect(mockInvoke).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("success toast", () => {
+    it("shows toast after successful submit", async () => {
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText(/brief summary/i),
+        "Bug title",
+      );
+      await user.click(
+        screen.getByRole("button", { name: /file on github/i }),
+      );
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledTimes(1);
+      });
+
+      const [message, options] = mockToast.mock.calls[0];
+      expect(message).toContain("Bug bundle saved");
+      expect(options.duration).toBe(Infinity);
+      expect(options.action.label).toBe("Reveal in File Manager");
+      expect(options.cancel.label).toBe("Copy path");
+    });
+
+    it("reveal action invokes fileManager", async () => {
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText(/brief summary/i),
+        "Bug title",
+      );
+      await user.click(
+        screen.getByRole("button", { name: /file on github/i }),
+      );
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalled();
+      });
+
+      const [, options] = mockToast.mock.calls[0];
+      options.action.onClick();
+
+      expect(mockRevealInFileManager).toHaveBeenCalledWith(
+        "/tmp/tandem-bug-test.zip",
+      );
+    });
+
+    it("shows browser-failed toast when openUrl rejects", async () => {
+      mockOpenUrl.mockRejectedValueOnce(new Error("no browser"));
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText(/brief summary/i),
+        "Bug title",
+      );
+      await user.click(
+        screen.getByRole("button", { name: /file on github/i }),
+      );
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledTimes(1);
+      });
+
+      const [message] = mockToast.mock.calls[0];
+      expect(message).toContain("Couldn't open browser");
     });
   });
 

--- a/ui/tandem/src/features/bugReport/ui/__tests__/BugReportModal.test.tsx
+++ b/ui/tandem/src/features/bugReport/ui/__tests__/BugReportModal.test.tsx
@@ -1,12 +1,21 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { BugReportModal, buildIssueUrl } from "../BugReportModal";
+import {
+  BugReportModal,
+  buildIssueUrl,
+  MAX_DESCRIPTION_LENGTH,
+} from "../BugReportModal";
 
 const mockOpenUrl = vi.fn().mockResolvedValue(undefined);
+const mockInvoke = vi.fn();
 
 vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: (...args: unknown[]) => mockOpenUrl(...args),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
 }));
 
 const defaultProps = {
@@ -17,6 +26,10 @@ const defaultProps = {
 describe("BugReportModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockInvoke.mockResolvedValue({
+      zipPath: "/tmp/tandem-bug-test.zip",
+      manifest: "## Environment\n- App version: 0.1.0",
+    });
   });
 
   it("renders when open", () => {
@@ -70,21 +83,10 @@ describe("BugReportModal", () => {
       });
       expect(submitButton).toBeEnabled();
     });
-
-    it("treats whitespace-only title as too short", async () => {
-      const user = userEvent.setup();
-      render(<BugReportModal {...defaultProps} />);
-      const titleInput = screen.getByPlaceholderText(/brief summary/i);
-      await user.type(titleInput, "   ");
-      const submitButton = screen.getByRole("button", {
-        name: /file on github/i,
-      });
-      expect(submitButton).toBeDisabled();
-    });
   });
 
-  describe("submit", () => {
-    it("calls opener with expected URL on submit", async () => {
+  describe("submit flow", () => {
+    it("invokes bundle_bug_report and opens URL on submit", async () => {
       const user = userEvent.setup();
       const onOpenChange = vi.fn();
       render(<BugReportModal open={true} onOpenChange={onOpenChange} />);
@@ -97,10 +99,15 @@ describe("BugReportModal", () => {
         screen.getByPlaceholderText(/what were you doing/i),
         "It broke",
       );
-
       await user.click(
         screen.getByRole("button", { name: /file on github/i }),
       );
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith("bundle_bug_report", {
+          screenshots: [],
+        });
+      });
 
       await waitFor(() => {
         expect(mockOpenUrl).toHaveBeenCalledTimes(1);
@@ -111,7 +118,7 @@ describe("BugReportModal", () => {
         "https://github.com/larkinmaxim/tandem/issues/new",
       );
       expect(calledUrl).toContain("title=My+bug+title");
-      expect(calledUrl).toContain("body=It+broke");
+      expect(calledUrl).toContain("It+broke");
     });
 
     it("closes modal after successful submit", async () => {
@@ -131,6 +138,246 @@ describe("BugReportModal", () => {
         expect(onOpenChange).toHaveBeenCalledWith(false);
       });
     });
+
+    it("shows spinner during submit", async () => {
+      let resolveInvoke: (value: unknown) => void;
+      mockInvoke.mockReturnValue(
+        new Promise((resolve) => {
+          resolveInvoke = resolve;
+        }),
+      );
+
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText(/brief summary/i),
+        "Bug title",
+      );
+      await user.click(
+        screen.getByRole("button", { name: /file on github/i }),
+      );
+
+      expect(screen.getByText(/preparing bundle/i)).toBeInTheDocument();
+      expect(screen.getByRole("status")).toBeInTheDocument();
+
+      resolveInvoke!({
+        zipPath: "/tmp/test.zip",
+        manifest: "test",
+      });
+
+      await waitFor(() => {
+        expect(mockOpenUrl).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("error handling", () => {
+    it("shows error and retry button on invoke failure", async () => {
+      mockInvoke.mockRejectedValue(new Error("disk full"));
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText(/brief summary/i),
+        "Bug title",
+      );
+      await user.click(
+        screen.getByRole("button", { name: /file on github/i }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+      expect(screen.getByText(/disk full/)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /retry/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("modal stays open on error", async () => {
+      mockInvoke.mockRejectedValue(new Error("failed"));
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+      render(<BugReportModal open={true} onOpenChange={onOpenChange} />);
+
+      await user.type(
+        screen.getByPlaceholderText(/brief summary/i),
+        "Bug title",
+      );
+      await user.click(
+        screen.getByRole("button", { name: /file on github/i }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+      expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    });
+
+    it("retry re-runs submission", async () => {
+      mockInvoke.mockRejectedValueOnce(new Error("temporary failure"));
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText(/brief summary/i),
+        "Bug title",
+      );
+      await user.click(
+        screen.getByRole("button", { name: /file on github/i }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /retry/i }),
+        ).toBeInTheDocument();
+      });
+
+      mockInvoke.mockResolvedValueOnce({
+        zipPath: "/tmp/test.zip",
+        manifest: "test",
+      });
+
+      await user.click(screen.getByRole("button", { name: /retry/i }));
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe("paste handler", () => {
+    it("handles image paste by preventing default and adding screenshot", async () => {
+      render(<BugReportModal {...defaultProps} />);
+      const textarea = screen.getByPlaceholderText(/what were you doing/i);
+
+      const imageBlob = new Blob(["fake-png-data"], { type: "image/png" });
+      const file = new File([imageBlob], "screenshot.png", {
+        type: "image/png",
+      });
+
+      const clipboardData = {
+        items: [
+          {
+            type: "image/png",
+            getAsFile: () => file,
+          },
+        ],
+      };
+
+      const pasteEvent = new Event("paste", { bubbles: true });
+      Object.defineProperty(pasteEvent, "clipboardData", {
+        value: clipboardData,
+      });
+      Object.defineProperty(pasteEvent, "preventDefault", {
+        value: vi.fn(),
+      });
+
+      textarea.dispatchEvent(pasteEvent);
+
+      await waitFor(() => {
+        expect(screen.getByText(/screenshot-1/)).toBeInTheDocument();
+      });
+    });
+
+    it("falls through for non-image paste", async () => {
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+      const textarea = screen.getByPlaceholderText(/what were you doing/i);
+
+      await user.click(textarea);
+      await user.paste("some text");
+
+      expect(textarea).toHaveValue("some text");
+      expect(screen.queryByText(/screenshot-/)).not.toBeInTheDocument();
+    });
+
+    it("rejects images > 10MB", async () => {
+      render(<BugReportModal {...defaultProps} />);
+      const textarea = screen.getByPlaceholderText(/what were you doing/i);
+
+      const largeBlob = new Blob([new Uint8Array(11 * 1024 * 1024)], {
+        type: "image/png",
+      });
+      const file = new File([largeBlob], "huge.png", { type: "image/png" });
+
+      const clipboardData = {
+        items: [
+          {
+            type: "image/png",
+            getAsFile: () => file,
+          },
+        ],
+      };
+
+      const pasteEvent = new Event("paste", { bubbles: true });
+      Object.defineProperty(pasteEvent, "clipboardData", {
+        value: clipboardData,
+      });
+      Object.defineProperty(pasteEvent, "preventDefault", {
+        value: vi.fn(),
+      });
+
+      textarea.dispatchEvent(pasteEvent);
+
+      await waitFor(() => {
+        expect(screen.getByText(/too large/i)).toBeInTheDocument();
+      });
+    });
+
+    it("supports multiple pasted images", async () => {
+      render(<BugReportModal {...defaultProps} />);
+      const textarea = screen.getByPlaceholderText(/what were you doing/i);
+
+      for (let i = 0; i < 2; i++) {
+        const imageBlob = new Blob(["fake-data"], { type: "image/png" });
+        const file = new File([imageBlob], `screenshot${i}.png`, {
+          type: "image/png",
+        });
+
+        const clipboardData = {
+          items: [
+            {
+              type: "image/png",
+              getAsFile: () => file,
+            },
+          ],
+        };
+
+        const pasteEvent = new Event("paste", { bubbles: true });
+        Object.defineProperty(pasteEvent, "clipboardData", {
+          value: clipboardData,
+        });
+        Object.defineProperty(pasteEvent, "preventDefault", {
+          value: vi.fn(),
+        });
+
+        textarea.dispatchEvent(pasteEvent);
+      }
+
+      await waitFor(() => {
+        expect(screen.getByText(/screenshot-1/)).toBeInTheDocument();
+        expect(screen.getByText(/screenshot-2/)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("description truncation", () => {
+    it("shows truncation notice when description exceeds max length", async () => {
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+      const textarea = screen.getByPlaceholderText(/what were you doing/i);
+
+      const longText = "x".repeat(MAX_DESCRIPTION_LENGTH + 100);
+      await user.click(textarea);
+      // Use fireEvent for efficiency with large strings
+      await userEvent.paste(longText);
+
+      await waitFor(() => {
+        expect(screen.getByText(/will be truncated/i)).toBeInTheDocument();
+      });
+    });
   });
 
   describe("cancel", () => {
@@ -142,30 +389,28 @@ describe("BugReportModal", () => {
       await user.click(screen.getByRole("button", { name: /cancel/i }));
 
       expect(onOpenChange).toHaveBeenCalledWith(false);
-      expect(mockOpenUrl).not.toHaveBeenCalled();
+      expect(mockInvoke).not.toHaveBeenCalled();
     });
   });
 
   describe("buildIssueUrl", () => {
-    it("encodes title and description", () => {
-      const url = buildIssueUrl("My Bug", "Steps to reproduce");
+    it("includes manifest in body", () => {
+      const url = buildIssueUrl("Bug", "Steps", "## Environment\n- v1");
+      expect(url).toContain("title=Bug");
+      expect(url).toContain("Steps");
+      expect(url).toContain("Environment");
+    });
+
+    it("omits body when both description and manifest are empty", () => {
+      const url = buildIssueUrl("Bug", "", "");
       expect(url).toBe(
-        "https://github.com/larkinmaxim/tandem/issues/new?title=My+Bug&body=Steps+to+reproduce",
+        "https://github.com/larkinmaxim/tandem/issues/new?title=Bug",
       );
     });
 
-    it("omits body param when description is empty", () => {
-      const url = buildIssueUrl("My Bug", "");
-      expect(url).toBe(
-        "https://github.com/larkinmaxim/tandem/issues/new?title=My+Bug",
-      );
-    });
-
-    it("trims whitespace from title and description", () => {
-      const url = buildIssueUrl("  Bug  ", "  desc  ");
-      expect(url).toBe(
-        "https://github.com/larkinmaxim/tandem/issues/new?title=Bug&body=desc",
-      );
+    it("includes manifest even without description", () => {
+      const url = buildIssueUrl("Bug", "", "## Env");
+      expect(url).toContain("body=%23%23+Env");
     });
   });
 });

--- a/ui/tandem/src/features/bugReport/ui/__tests__/BugReportModal.test.tsx
+++ b/ui/tandem/src/features/bugReport/ui/__tests__/BugReportModal.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { BugReportModal, buildIssueUrl } from "../BugReportModal";
+
+const mockOpenUrl = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: (...args: unknown[]) => mockOpenUrl(...args),
+}));
+
+const defaultProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+};
+
+describe("BugReportModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders when open", () => {
+    render(<BugReportModal {...defaultProps} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Report a Bug")).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    render(<BugReportModal {...defaultProps} open={false} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  describe("title validation", () => {
+    it("disables submit when title is empty", () => {
+      render(<BugReportModal {...defaultProps} />);
+      const submitButton = screen.getByRole("button", {
+        name: /file on github/i,
+      });
+      expect(submitButton).toBeDisabled();
+    });
+
+    it("disables submit when trimmed title has fewer than 3 characters", async () => {
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+      const titleInput = screen.getByPlaceholderText(/brief summary/i);
+      await user.type(titleInput, "ab");
+      const submitButton = screen.getByRole("button", {
+        name: /file on github/i,
+      });
+      expect(submitButton).toBeDisabled();
+    });
+
+    it("shows validation message when title is non-empty but too short", async () => {
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+      const titleInput = screen.getByPlaceholderText(/brief summary/i);
+      await user.type(titleInput, "ab");
+      expect(
+        screen.getByText(/title must be at least 3 characters/i),
+      ).toBeInTheDocument();
+    });
+
+    it("enables submit when title has 3+ characters", async () => {
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+      const titleInput = screen.getByPlaceholderText(/brief summary/i);
+      await user.type(titleInput, "abc");
+      const submitButton = screen.getByRole("button", {
+        name: /file on github/i,
+      });
+      expect(submitButton).toBeEnabled();
+    });
+
+    it("treats whitespace-only title as too short", async () => {
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+      const titleInput = screen.getByPlaceholderText(/brief summary/i);
+      await user.type(titleInput, "   ");
+      const submitButton = screen.getByRole("button", {
+        name: /file on github/i,
+      });
+      expect(submitButton).toBeDisabled();
+    });
+  });
+
+  describe("submit", () => {
+    it("calls opener with expected URL on submit", async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(<BugReportModal open={true} onOpenChange={onOpenChange} />);
+
+      await user.type(
+        screen.getByPlaceholderText(/brief summary/i),
+        "My bug title",
+      );
+      await user.type(
+        screen.getByPlaceholderText(/what were you doing/i),
+        "It broke",
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: /file on github/i }),
+      );
+
+      await waitFor(() => {
+        expect(mockOpenUrl).toHaveBeenCalledTimes(1);
+      });
+
+      const calledUrl = mockOpenUrl.mock.calls[0][0] as string;
+      expect(calledUrl).toContain(
+        "https://github.com/larkinmaxim/tandem/issues/new",
+      );
+      expect(calledUrl).toContain("title=My+bug+title");
+      expect(calledUrl).toContain("body=It+broke");
+    });
+
+    it("closes modal after successful submit", async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(<BugReportModal open={true} onOpenChange={onOpenChange} />);
+
+      await user.type(
+        screen.getByPlaceholderText(/brief summary/i),
+        "Bug title",
+      );
+      await user.click(
+        screen.getByRole("button", { name: /file on github/i }),
+      );
+
+      await waitFor(() => {
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+      });
+    });
+  });
+
+  describe("cancel", () => {
+    it("closes modal on cancel", async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(<BugReportModal open={true} onOpenChange={onOpenChange} />);
+
+      await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(mockOpenUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("buildIssueUrl", () => {
+    it("encodes title and description", () => {
+      const url = buildIssueUrl("My Bug", "Steps to reproduce");
+      expect(url).toBe(
+        "https://github.com/larkinmaxim/tandem/issues/new?title=My+Bug&body=Steps+to+reproduce",
+      );
+    });
+
+    it("omits body param when description is empty", () => {
+      const url = buildIssueUrl("My Bug", "");
+      expect(url).toBe(
+        "https://github.com/larkinmaxim/tandem/issues/new?title=My+Bug",
+      );
+    });
+
+    it("trims whitespace from title and description", () => {
+      const url = buildIssueUrl("  Bug  ", "  desc  ");
+      expect(url).toBe(
+        "https://github.com/larkinmaxim/tandem/issues/new?title=Bug&body=desc",
+      );
+    });
+  });
+});

--- a/ui/tandem/src/features/bugReport/ui/__tests__/BugReportModal.test.tsx
+++ b/ui/tandem/src/features/bugReport/ui/__tests__/BugReportModal.test.tsx
@@ -32,6 +32,12 @@ vi.mock("@/shared/lib/platform", () => ({
   getPlatform: () => "linux",
 }));
 
+let mockActiveSessionId: string | null = null;
+vi.mock("@/features/chat/stores/chatSessionStore", () => ({
+  useChatSessionStore: (selector: (s: { activeSessionId: string | null }) => unknown) =>
+    selector({ activeSessionId: mockActiveSessionId }),
+}));
+
 const defaultProps = {
   open: true,
   onOpenChange: vi.fn(),
@@ -40,6 +46,7 @@ const defaultProps = {
 describe("BugReportModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockActiveSessionId = null;
     mockInvoke.mockResolvedValue({
       zipPath: "/tmp/tandem-bug-test.zip",
       manifest: "## Environment\n- App version: 0.1.0",
@@ -481,6 +488,55 @@ describe("BugReportModal", () => {
 
       const [message] = mockToast.mock.calls[0];
       expect(message).toContain("Couldn't open browser");
+    });
+  });
+
+  describe("session ID passthrough", () => {
+    it("passes activeSessionId to bundle_bug_report when session is active", async () => {
+      mockActiveSessionId = "sess-abc-123";
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText(/brief summary/i),
+        "Bug title",
+      );
+      await user.click(
+        screen.getByRole("button", { name: /file on github/i }),
+      );
+
+      await waitFor(() => {
+        const bundleCalls = mockInvoke.mock.calls.filter(
+          (c) => c[0] === "bundle_bug_report",
+        );
+        expect(bundleCalls).toHaveLength(1);
+        expect(bundleCalls[0][1]).toEqual({
+          screenshots: [],
+          sessionId: "sess-abc-123",
+        });
+      });
+    });
+
+    it("omits sessionId when no active session", async () => {
+      mockActiveSessionId = null;
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText(/brief summary/i),
+        "Bug title",
+      );
+      await user.click(
+        screen.getByRole("button", { name: /file on github/i }),
+      );
+
+      await waitFor(() => {
+        const bundleCalls = mockInvoke.mock.calls.filter(
+          (c) => c[0] === "bundle_bug_report",
+        );
+        expect(bundleCalls).toHaveLength(1);
+        expect(bundleCalls[0][1].sessionId).toBeUndefined();
+      });
     });
   });
 

--- a/ui/tandem/src/features/bugReport/ui/__tests__/BugReportModal.test.tsx
+++ b/ui/tandem/src/features/bugReport/ui/__tests__/BugReportModal.test.tsx
@@ -234,6 +234,10 @@ describe("BugReportModal", () => {
         ).toBeInTheDocument();
       });
 
+      const callsBefore = mockInvoke.mock.calls.filter(
+        (c) => c[0] === "bundle_bug_report",
+      ).length;
+
       mockInvoke.mockResolvedValueOnce({
         zipPath: "/tmp/test.zip",
         manifest: "test",
@@ -242,7 +246,10 @@ describe("BugReportModal", () => {
       await user.click(screen.getByRole("button", { name: /retry/i }));
 
       await waitFor(() => {
-        expect(mockInvoke).toHaveBeenCalledTimes(2);
+        const callsAfter = mockInvoke.mock.calls.filter(
+          (c) => c[0] === "bundle_bug_report",
+        ).length;
+        expect(callsAfter).toBe(callsBefore + 1);
       });
     });
   });

--- a/ui/tandem/src/features/chat/ui/ChatInputToolbar.tsx
+++ b/ui/tandem/src/features/chat/ui/ChatInputToolbar.tsx
@@ -35,6 +35,7 @@ import {
   getCatalogEntry,
   resolveAgentProviderCatalogIdStrict,
 } from "@/features/providers/providerCatalog";
+import { BugReportButton } from "@/features/bugReport/ui/BugReportButton";
 
 const NO_PROJECT_VALUE = "__no_project__";
 const CREATE_PROJECT_VALUE = "__create_project__";
@@ -354,6 +355,8 @@ export function ChatInputToolbar({
               </PopoverContent>
             </Popover>
           )}
+
+          <BugReportButton />
 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/ui/tandem/src/shared/i18n/constants.ts
+++ b/ui/tandem/src/shared/i18n/constants.ts
@@ -3,6 +3,7 @@ export const SUPPORTED_LOCALES = ["en", "es"] as const;
 export const DEFAULT_NAMESPACE = "common";
 export const TRANSLATION_NAMESPACES = [
   "agents",
+  "bugReport",
   "common",
   "chat",
   "home",

--- a/ui/tandem/src/shared/i18n/i18n.ts
+++ b/ui/tandem/src/shared/i18n/i18n.ts
@@ -29,6 +29,7 @@ function normalizeSupportedLocale(locale?: string | null): AppLocale | null {
 const localeResourceLoaders = {
   en: {
     agents: () => import("./locales/en/agents.json"),
+    bugReport: () => import("./locales/en/bugReport.json"),
     common: () => import("./locales/en/common.json"),
     chat: () => import("./locales/en/chat.json"),
     home: () => import("./locales/en/home.json"),
@@ -41,6 +42,7 @@ const localeResourceLoaders = {
   },
   es: {
     agents: () => import("./locales/es/agents.json"),
+    bugReport: () => import("./locales/es/bugReport.json"),
     common: () => import("./locales/es/common.json"),
     chat: () => import("./locales/es/chat.json"),
     home: () => import("./locales/es/home.json"),

--- a/ui/tandem/src/shared/i18n/locales/en/bugReport.json
+++ b/ui/tandem/src/shared/i18n/locales/en/bugReport.json
@@ -11,6 +11,13 @@
     "descriptionLabel": "Description",
     "descriptionPlaceholder": "What were you doing? What did you expect? You can paste a screenshot here.",
     "submit": "File on GitHub",
-    "cancel": "Cancel"
+    "submitting": "Preparing bundle…",
+    "cancel": "Cancel",
+    "retry": "Retry",
+    "error": "Couldn't prepare bug bundle: {{reason}}",
+    "truncationNotice": "Description will be truncated to {{limit}} characters ({{excess}} chars will be omitted)",
+    "screenshotChip": "screenshot-{{index}}",
+    "screenshotTooLarge": "Screenshot too large ({{size}} MB) — GitHub caps at 10 MB. Crop and try again.",
+    "removeScreenshot": "Remove screenshot {{index}}"
   }
 }

--- a/ui/tandem/src/shared/i18n/locales/en/bugReport.json
+++ b/ui/tandem/src/shared/i18n/locales/en/bugReport.json
@@ -1,0 +1,16 @@
+{
+  "button": {
+    "label": "Report a bug"
+  },
+  "modal": {
+    "title": "Report a Bug",
+    "description": "File an issue on GitHub so we can investigate.",
+    "titleLabel": "Title",
+    "titlePlaceholder": "Brief summary (e.g. Sidebar collapses on resize)",
+    "titleValidation": "Title must be at least 3 characters",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "What were you doing? What did you expect? You can paste a screenshot here.",
+    "submit": "File on GitHub",
+    "cancel": "Cancel"
+  }
+}

--- a/ui/tandem/src/shared/i18n/locales/en/bugReport.json
+++ b/ui/tandem/src/shared/i18n/locales/en/bugReport.json
@@ -19,5 +19,13 @@
     "screenshotChip": "screenshot-{{index}}",
     "screenshotTooLarge": "Screenshot too large ({{size}} MB) — GitHub caps at 10 MB. Crop and try again.",
     "removeScreenshot": "Remove screenshot {{index}}"
+  },
+  "toast": {
+    "success": "Bug bundle saved · Drag {{filename}} onto your GitHub issue",
+    "revealInFinder": "Reveal in Finder",
+    "revealInExplorer": "Reveal in Explorer",
+    "revealInFileManager": "Reveal in File Manager",
+    "copyPath": "Copy path",
+    "browserFailed": "Couldn't open browser · URL copied — paste into your browser to file the issue"
   }
 }

--- a/ui/tandem/src/shared/i18n/locales/es/bugReport.json
+++ b/ui/tandem/src/shared/i18n/locales/es/bugReport.json
@@ -11,6 +11,13 @@
     "descriptionLabel": "Description",
     "descriptionPlaceholder": "What were you doing? What did you expect? You can paste a screenshot here.",
     "submit": "File on GitHub",
-    "cancel": "Cancel"
+    "submitting": "Preparing bundle…",
+    "cancel": "Cancel",
+    "retry": "Retry",
+    "error": "Couldn't prepare bug bundle: {{reason}}",
+    "truncationNotice": "Description will be truncated to {{limit}} characters ({{excess}} chars will be omitted)",
+    "screenshotChip": "screenshot-{{index}}",
+    "screenshotTooLarge": "Screenshot too large ({{size}} MB) — GitHub caps at 10 MB. Crop and try again.",
+    "removeScreenshot": "Remove screenshot {{index}}"
   }
 }

--- a/ui/tandem/src/shared/i18n/locales/es/bugReport.json
+++ b/ui/tandem/src/shared/i18n/locales/es/bugReport.json
@@ -1,0 +1,16 @@
+{
+  "button": {
+    "label": "Report a bug"
+  },
+  "modal": {
+    "title": "Report a Bug",
+    "description": "File an issue on GitHub so we can investigate.",
+    "titleLabel": "Title",
+    "titlePlaceholder": "Brief summary (e.g. Sidebar collapses on resize)",
+    "titleValidation": "Title must be at least 3 characters",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "What were you doing? What did you expect? You can paste a screenshot here.",
+    "submit": "File on GitHub",
+    "cancel": "Cancel"
+  }
+}

--- a/ui/tandem/src/shared/i18n/locales/es/bugReport.json
+++ b/ui/tandem/src/shared/i18n/locales/es/bugReport.json
@@ -19,5 +19,13 @@
     "screenshotChip": "screenshot-{{index}}",
     "screenshotTooLarge": "Screenshot too large ({{size}} MB) — GitHub caps at 10 MB. Crop and try again.",
     "removeScreenshot": "Remove screenshot {{index}}"
+  },
+  "toast": {
+    "success": "Bug bundle saved · Drag {{filename}} onto your GitHub issue",
+    "revealInFinder": "Reveal in Finder",
+    "revealInExplorer": "Reveal in Explorer",
+    "revealInFileManager": "Reveal in File Manager",
+    "copyPath": "Copy path",
+    "browserFailed": "Couldn't open browser · URL copied — paste into your browser to file the issue"
   }
 }


### PR DESCRIPTION
## Summary

Adds an in-app bug report flow for Tandem (Issues #50–#55):

- **#50** — Skeleton modal + composer toolbar button, opens GitHub issue URL
- **#51** — Rust `bundle_bug_report` command that gathers logs/config and applies redaction
- **#52** — Wires modal to the Rust command, supports paste-to-attach screenshots, handles failures
- **#53** — Success toast with reveal-in-finder action; browser-open failure path
- **#54** — PostHog `bug_report_submitted` event with respect for telemetry opt-out
- **#55** — Includes `session.json` from goose-server in the bundle

All changes are scoped to `ui/tandem/` (and its Tauri `src-tauri/`) — no `ui/goose2/` touchpoints.

## Test plan

- [ ] Open composer → click bug-report button → modal renders
- [ ] Paste a screenshot into the modal → it attaches
- [ ] Submit → bundle is generated, GitHub URL opens, success toast appears
- [ ] Click "Reveal in Finder" on the toast → bundle directory opens
- [ ] Confirm bundled `session.json` is present and redacted fields are scrubbed
- [ ] With telemetry opt-out enabled, confirm no PostHog event fires
- [ ] `cargo test` in `ui/tandem/src-tauri/` passes
- [ ] `pnpm test` in `ui/tandem/` passes (BugReportModal + telemetry tests)
