### PR TITLE
fix(tandem): bug report bundle gaps — logs on Windows/macOS + session auth

### DIFF
--- a/ui/tandem/src-tauri/Cargo.toml
+++ b/ui/tandem/src-tauri/Cargo.toml
@@ -39,6 +39,8 @@ mime_guess = "2"
 tauri-plugin-shell = "2"
 zip = "0.6"
 regex = "1"
+rand = "0.8"
+hex = "0.4"
 reqwest = { version = "0.12", features = ["json"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/ui/tandem/src-tauri/src/commands/bug_report.rs
+++ b/ui/tandem/src-tauri/src/commands/bug_report.rs
@@ -1,12 +1,12 @@
 use base64::Engine;
 use chrono::Utc;
-use etcetera::{choose_app_strategy, AppStrategy, AppStrategyArgs};
+use etcetera::{AppStrategy, AppStrategyArgs, choose_app_strategy};
 use regex::Regex;
 use serde::Serialize;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use zip::write::FileOptions;
 use zip::ZipWriter;
+use zip::write::FileOptions;
 
 const MAX_FILE_BYTES: u64 = 1_048_576; // 1 MB
 const OMISSION_MARKER: &str = "\n... ({} bytes omitted) ...\n";
@@ -31,9 +31,8 @@ fn resolve_state_dir() -> Option<PathBuf> {
     if let Ok(root) = std::env::var("GOOSE_PATH_ROOT") {
         return Some(PathBuf::from(root).join("state"));
     }
-    choose_app_strategy(app_strategy()?)
-        .ok()
-        .and_then(|s| s.state_dir())
+    let strategy = choose_app_strategy(app_strategy()?).ok()?;
+    Some(strategy.state_dir().unwrap_or_else(|| strategy.data_dir()))
 }
 
 fn resolve_config_dir() -> Option<PathBuf> {
@@ -238,7 +237,9 @@ fn build_manifest(recent_errors: &str, session_id: Option<&str>) -> String {
     let errors_section = if recent_errors == "_No recent errors._" {
         "_No recent errors._".to_string()
     } else {
-        format!("<details>\n<summary>Last errors/warnings</summary>\n\n```\n{recent_errors}\n```\n</details>")
+        format!(
+            "<details>\n<summary>Last errors/warnings</summary>\n\n```\n{recent_errors}\n```\n</details>"
+        )
     };
 
     format!(
@@ -629,9 +630,11 @@ normal_setting: keep-this
         let result = extract_recent_errors(&log_path, 5);
         let lines: Vec<&str> = result.lines().collect();
         assert!(lines.len() <= 5);
-        assert!(lines
-            .iter()
-            .all(|l| l.contains("ERROR") || l.contains("WARN")));
+        assert!(
+            lines
+                .iter()
+                .all(|l| l.contains("ERROR") || l.contains("WARN"))
+        );
     }
 
     #[test]
@@ -756,5 +759,15 @@ normal_setting: keep-this
             .collect();
 
         assert!(!names.contains(&"session.json".to_string()));
+    }
+
+    #[test]
+    fn resolve_state_dir_never_returns_none() {
+        let dir = tempdir().unwrap();
+        std::env::set_var("GOOSE_PATH_ROOT", dir.path().to_string_lossy().as_ref());
+        let result = resolve_state_dir();
+        std::env::remove_var("GOOSE_PATH_ROOT");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), dir.path().join("state"));
     }
 }

--- a/ui/tandem/src-tauri/src/commands/bug_report.rs
+++ b/ui/tandem/src-tauri/src/commands/bug_report.rs
@@ -375,9 +375,14 @@ pub fn bundle_bug_report_impl(
     })
 }
 
-async fn fetch_session_export(port: u16, session_id: &str) -> Option<String> {
+async fn fetch_session_export(port: u16, session_id: &str, secret: &str) -> Option<String> {
     let url = format!("http://127.0.0.1:{port}/sessions/{session_id}/export");
-    let resp = reqwest::get(&url).await.ok()?;
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .header("X-Secret-Key", secret)
+        .send()
+        .await
+        .ok()?;
     if !resp.status().is_success() {
         return None;
     }
@@ -399,7 +404,7 @@ pub async fn bundle_bug_report(
                     .last()
                     .and_then(|s| s.trim_end_matches("/acp").parse::<u16>().ok());
                 if let Some(port) = port {
-                    fetch_session_export(port, sid).await
+                    fetch_session_export(port, sid, process.secret_key()).await
                 } else {
                     None
                 }

--- a/ui/tandem/src-tauri/src/services/acp/goose_serve.rs
+++ b/ui/tandem/src-tauri/src/services/acp/goose_serve.rs
@@ -20,6 +20,7 @@ const LOCALHOST: &str = "127.0.0.1";
 /// concurrent sessions.
 pub struct GooseServeProcess {
     port: u16,
+    secret: String,
     _child: Child,
 }
 
@@ -32,6 +33,10 @@ impl GooseServeProcess {
         format!("ws://{LOCALHOST}:{}/acp", self.port)
     }
 
+    pub fn secret_key(&self) -> &str {
+        &self.secret
+    }
+
     /// Get a reference to the running process, or an error if it was never
     /// started (should not happen in normal operation).
     pub async fn get(app_handle: tauri::AppHandle) -> Result<&'static GooseServeProcess, String> {
@@ -42,6 +47,7 @@ impl GooseServeProcess {
 
     async fn spawn(app_handle: tauri::AppHandle) -> Result<GooseServeProcess, String> {
         let port = reserve_free_port()?;
+        let secret = hex::encode(rand::random::<[u8; 32]>());
 
         // Use a stable working directory for the long-lived server process.
         // Individual sessions will set their own cwd via the ACP protocol.
@@ -62,6 +68,7 @@ impl GooseServeProcess {
             .arg(LOCALHOST)
             .arg("--port")
             .arg(port.to_string())
+            .env("GOOSE_SERVER__SECRET_KEY", &secret)
             .current_dir(&working_dir)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
@@ -86,6 +93,7 @@ impl GooseServeProcess {
 
         Ok(GooseServeProcess {
             port,
+            secret,
             _child: child,
         })
     }


### PR DESCRIPTION
## Summary
Closes the two PR #56 follow-up gaps that were merged-but-broken:

- **#59** — `resolve_state_dir()` now falls back to `data_dir()` when `state_dir()` returns `None` on Windows/macOS, mirroring `crates/goose/src/config/paths.rs`. Server logs and JSONL files are now included in bug report bundles on all platforms.
- **#60** — `GooseServeProcess` generates a secret key at spawn time and passes it via `GOOSE_SERVER__SECRET_KEY`; `fetch_session_export` now sends `X-Secret-Key`, so `/sessions/{id}/export` actually authenticates and `session.json` makes it into the bundle.

Commits: `7e30fede` (#59), `5f07bca7` (#60).

`#61` (paste-screenshot e2e) is still open and untouched — separate PR.

## Test plan
- [ ] On Windows: open bug report modal, submit, unzip — server logs + JSONL present.
- [ ] On macOS: same check.
- [ ] With an active session, submit a report — `session.json` present in the ZIP and manifest shows `Session: <id>`.
- [ ] Tauri/Rust tests green.

Generated with Claude Code
